### PR TITLE
Updated Pixel Service API (NeoPixel and DotStar)

### DIFF
--- a/proto/wippersnapper/pixel/v1/pixel.proto
+++ b/proto/wippersnapper/pixel/v1/pixel.proto
@@ -30,11 +30,11 @@ message ConfigurePixels {
         PIXEL_ORDER_NEOPIXEL_GRBW = 5;
         // Dotstar transmit order
         PIXEL_ORDER_DOTSTAR_RGB = 6;
-        PIXEL_ORDER_NEOPIXEL_RBG = 7;
-        PIXEL_ORDER_NEOPIXEL_GRB = 8;
-        PIXEL_ORDER_NEOPIXEL_GBR = 9;
-        PIXEL_ORDER_NEOPIXEL_BGR = 10;
-        PIXEL_ORDER_NEOPIXEL_BRG = 11;
+        PIXEL_ORDER_DOTSTAR_RBG = 7;
+        PIXEL_ORDER_DOTSTAR_GRB = 8;
+        PIXEL_ORDER_DOTSTAR_GBR = 9;
+        PIXEL_ORDER_DOTSTAR_BGR = 10;
+        PIXEL_ORDER_DOTSTAR_BRG = 11;
     }
 
     // Pin to send data to
@@ -57,12 +57,12 @@ message PixelEvent {
     // second is red, then green, and least significant byte is blue.
     // e.g. 0x00RRGGBB.
     // If all arguments are unspecified, this will be 0 (off).
-    uint32 color = 0;
+    uint32 color = 1;
 
     // Index of first pixel from 0, starting from 0
-    uint32 first_pixel = 1;
+    uint32 idx_first_pixel = 2;
 
     // Number of pixels to fill.
     // Note - Passing 0 or leaving unspecified will fill to end of a pixel strip.
-    uint32 pixel_count = 2;
+    uint32 pixel_count = 3;
 }

--- a/proto/wippersnapper/signal/v1/signal.proto
+++ b/proto/wippersnapper/signal/v1/signal.proto
@@ -6,6 +6,7 @@ package wippersnapper.signal.v1;
 
 import "wippersnapper/pin/v1/pin.proto";
 import "wippersnapper/sensor/v1/sensor.proto";
+import "wippersnapper/pixel/v1/pixel.proto";
 
 
 message CreateSignalRequest {
@@ -22,6 +23,10 @@ message CreateSignalRequest {
     wippersnapper.pin.v1.ConfigurePWMPinRequests pwm_pin_config         = 10;
     // Write duty cycle to a PWM output pin
     wippersnapper.pin.v1.PWMPinEvents pwm_pin_event                     = 12;
+    // Configure addressible pixel hardware
+    wippersnapper.pixel.v1.ConfigurePixels pixel_config                 = 13;
+    // Transmit pixel data
+    wippersnapper.pixel.v1.PixelEvent pixel_event                       = 14;
   }
 }
 


### PR DESCRIPTION
Refactored the pixel service API to communicate with NeoPixel and DotStar LEDs.

* added `ConfigurePixels` C2D message which provides info about the type of pixel constructor to use, the pixel ordering, and the number of the pixels on a strip. Currently we only support NeoPixel and Dotstar, but this api should be extensible enough to add more.

* added `PixelEvent` C2D message which transmits pixel data (color, index of pixels to address). We can add parameters like brightness later. 