### PR TITLE
Include the nanopb.proto file for protoc

### DIFF
--- a/.github/workflows/protoc-wrapper-generation.yml
+++ b/.github/workflows/protoc-wrapper-generation.yml
@@ -32,7 +32,7 @@ jobs:
         mkdir ./js_out
         ls -la
         protoc --proto_path=./protobuf-checkout/proto ./protobuf-checkout/proto/wippersnapper/*/*/*.proto --js_out=import_style=commonjs,binary:js_out --python_out=./python_out
-        protoc -I=./protobuf-checkout/nanopb/generator/proto/nanopb.proto --js_out=import_style=commonjs,binary:js_out --python_out=./python_out
+        protoc -I=./protobuf-checkout/proto/nanopb/nanopb.proto --js_out=import_style=commonjs,binary:js_out --python_out=./python_out
     - name: Checkout Python Repo
       uses: actions/checkout@v2
       with:


### PR DESCRIPTION
Including path to `nanopb.proto` for Python and JS stub generation