### PR TITLE
Switch to in-proto nanopb options

### DIFF
--- a/proto/wippersnapper/description/v1/description.options
+++ b/proto/wippersnapper/description/v1/description.options
@@ -1,1 +1,0 @@
-wippersnapper.description.v1.CreateDescriptionRequest.machine_name   max_size:64

--- a/proto/wippersnapper/description/v1/description.proto
+++ b/proto/wippersnapper/description/v1/description.proto
@@ -4,12 +4,13 @@
 syntax = "proto3";
 
 package wippersnapper.description.v1;
+import "nanopb/nanopb.proto";
 
 // Request sent by device to Adafruit IO to select
 // or update a device's board definition
 // MQTT Topic: `/devices/description/`
 message CreateDescriptionRequest {
-  string machine_name = 1; // Board identifier string
+  string machine_name = 1 [(nanopb).max_size = 64]; // Board identifier string
   int32 mac_addr      = 2; // Last 3 bytes of device MAC address
   int32 usb_vid       = 3; // Optional USB Vendor ID
   int32 usb_pid       = 4; // Optional USB Product ID

--- a/proto/wippersnapper/pin/v1/pin.options
+++ b/proto/wippersnapper/pin/v1/pin.options
@@ -1,4 +1,0 @@
-wippersnapper.pin.v1.ConfigurePinRequest.pin_name       max_size:5
-wippersnapper.pin.v1.PinEvent.pin_name                  max_size:5
-wippersnapper.pin.v1.PinEvent.pin_value                 max_size:12
-wippersnapper.pin.v1.ConfigurePWMPinRequest.pin_name    max_size:5

--- a/proto/wippersnapper/pin/v1/pin.proto
+++ b/proto/wippersnapper/pin/v1/pin.proto
@@ -3,12 +3,13 @@
 syntax = "proto3";
 
 package wippersnapper.pin.v1;
+import "nanopb/nanopb.proto";
 
 /* Pin API for interfacing with analog or digital pins  */
 // Request to create or update a pin's configuration
 // MQTT Topic: `/device/ID/signal`
 message ConfigurePinRequest {
-  string pin_name      = 1; // Name of pin to access
+  string pin_name      = 1 [(nanopb).max_size = 5]; // Name of pin to access
   Mode mode            = 2; // Pin mode
   Direction direction  = 3; // Pin direction
   Pull pull            = 4; // Pull value
@@ -58,8 +59,8 @@ message ConfigurePinResponse {
 
 // Sends data about the value of a pin, bi-directional
 message PinEvent {
-  string pin_name = 1;
-  string pin_value = 2;
+  string pin_name = 1 [(nanopb).max_size = 5];
+  string pin_value = 2 [(nanopb).max_size = 12];
 }
 
 message PinEvents {
@@ -82,7 +83,7 @@ message PinEventResponse {
 // Configures a PWM output pin
 message ConfigurePWMPinRequest {
   // Pin to write to
-  string pin_name         = 1;
+  string pin_name         = 1 [(nanopb).max_size = 5];
 
   // Duty cycle between always off (0)
   // and always on (255)


### PR DESCRIPTION
Replaces `.options` commands with inline options into proto files for portability and legibility. 

Compiled and verified locally with  Arduino Wippersnapper 

Addresses https://github.com/adafruit/Wippersnapper_Protobuf/issues/24