### PR TITLE
CreateDescriptionResponse responds with physical hardware pins

### DIFF
--- a/proto/wippersnapper/description/v1/description.proto
+++ b/proto/wippersnapper/description/v1/description.proto
@@ -33,7 +33,7 @@ message CreateDescriptionRequest {
 */
 message CreateDescriptionResponse {
   Response response        = 1; /** Specifies if the hardware definition exists on the server. */
-  int32 total_digital_pins = 2; /** Specifies the number of digital pins on the client's physical hardware */
+  int32 total_gpio_pins = 2; /** Specifies the number of GPIO pins on the client's physical hardware */
   int32 total_analog_pins  = 3; /** Specifies the number of analog pins on the client's physical hardware */
 
   /**


### PR DESCRIPTION
This pull request adds two new fields to `CreateDescriptionResponse`:
* `total_gpio_pins`: Specifies the total number of general-purpose pins on a device.
  * Values for this field are found within the board definition model's `digitalPins` array (https://github.com/adafruit/Wippersnapper_Boards/blob/master/definitions/adafruit-huzzah-32/definition.json#L11)
* `total_analog_pins`: Specifies the total number of analog-input capable pins on a device.
  * Values for this field are found within the board definition model's `analogPins` array

These fields will help tell the device the number of analog and digital input objects to dynamically allocate. 

Addresses https://github.com/adafruit/Wippersnapper_Protobuf/issues/33