### PR TITLE
Fix reference voltage configuration

### DIFF
--- a/proto/wippersnapper/description/v1/description.proto
+++ b/proto/wippersnapper/description/v1/description.proto
@@ -35,7 +35,7 @@ message CreateDescriptionResponse {
   Response response        = 1; /** Specifies if the hardware definition exists on the server. */
   int32 total_gpio_pins    = 2; /** Specifies the number of GPIO pins on the client's physical hardware. */
   int32 total_analog_pins  = 3; /** Specifies the number of analog pins on the client's physical hardware. */
-  float reference_voltage  = 4 [deprecated=true]; /** Specifies the hardware's default reference voltage. */
+  float reference_voltage  = 4; /** Specifies the hardware's default reference voltage. */
 
   /**
    * Response. Specifies if the hardware definiton is within the database.

--- a/proto/wippersnapper/pin/v1/pin.proto
+++ b/proto/wippersnapper/pin/v1/pin.proto
@@ -31,7 +31,7 @@ message ConfigurePinRequest {
   Pull pull                        = 4; /** Specifies an optional pullup resistor value. */
   float period                     = 5; /** Specifies the time between measurements, in seconds. */
   RequestType request_type         = 6; /** Specifies the type of ConfigurePinRequest. */
-  float aref                       = 7 [deprecated=true]; /** DEPRECIATED: Specifies the reference voltage used for analog input, defaults to 3.3v. */
+  float aref                       = 7 [deprecated=true]; /** deprecated: Specifies the reference voltage used for analog input, defaults to 3.3v. */
   AnalogReadMode analog_read_mode  = 8; /** ANALOG-ONLY: Specifies the read mode for an analog pin. */
 
   /**


### PR DESCRIPTION
We're currently setting the hardware's reference voltage with each `ConfigurePinRequest` message, but the reference voltage is set globally, not per-pin.

- `CreateDescriptionResponse` should now return the hardware definition model's `mcuRefVoltage` field (example: https://github.com/adafruit/Wippersnapper_Boards/blob/master/definitions/adafruit-huzzah-32/definition.json#L4)
- Deprecated `aref` field within `ConfigurePinRequest`
- Added `ConfigureReferenceVoltage` message to allow for user-configurable reference voltage, as a separate C2D message 