### PR TITLE
Update description's semantic versioning message

### DIFF
--- a/proto/wippersnapper/description/v1/description.proto
+++ b/proto/wippersnapper/description/v1/description.proto
@@ -17,15 +17,15 @@ message CreateDescriptionRequest {
   Version version     = 5; /** Client's library version. */
 
   message Version {
-  uint64 major           = 1 [deprecated = true, (nanopb).type = FT_IGNORE];
-  uint64 minor           = 2 [deprecated = true, (nanopb).type = FT_IGNORE];
-  uint64 micro           = 3 [deprecated = true, (nanopb).type = FT_IGNORE];
-  string label           = 4 [deprecated = true, (nanopb).type = FT_IGNORE];
-  int32 ver_major        = 5;
-  int32 ver_minor        = 6;
-  int32 ver_patch        = 7;
-  string ver_pre_release = 8;
-  int32 ver_build        = 9;
+    uint64 major           = 1 [deprecated = true, (nanopb).type = FT_IGNORE];
+    uint64 minor           = 2 [deprecated = true, (nanopb).type = FT_IGNORE];
+    uint64 micro           = 3 [deprecated = true, (nanopb).type = FT_IGNORE];
+    string label           = 4 [deprecated = true, (nanopb).type = FT_IGNORE];
+    int32 ver_major        = 5;
+    int32 ver_minor        = 6;
+    int32 ver_patch        = 7;
+    string ver_pre_release = 8;
+    int32 ver_build        = 9;
   }
 }
 


### PR DESCRIPTION
- Updates `Version` with new fields to use a different type, names.
- Adds a `ver_build` field for beta/pre-release builds
- Updates [deprecated=true] to include (nanopb).type = FT_IGNORE] so nanopb does not include deprecated fields into its MAX_SIZE calculation (https://github.com/nanopb/nanopb/issues/651)
  -  NOTE: We should do this globally in another PR

https://github.com/adafruit/Adafruit_Wippersnapper_Arduino/issues/71