### PR TITLE
Fix description.proto pre_release string len with nanopb compiler 

### DIFF
--- a/proto/wippersnapper/description/v1/description.proto
+++ b/proto/wippersnapper/description/v1/description.proto
@@ -24,7 +24,7 @@ message CreateDescriptionRequest {
     int32 ver_major        = 5;
     int32 ver_minor        = 6;
     int32 ver_patch        = 7;
-    string ver_pre_release = 8;
+    string ver_pre_release = 8 [(nanopb).max_size = 6];
     int32 ver_build        = 9;
   }
 }


### PR DESCRIPTION
Limits length of pre_rel string to 5 ("alpha" or "beta") characters + 1 null/esc character.