### PR TITLE
Add total # of i2c ports to registration response

### DIFF
--- a/proto/wippersnapper/description/v1/description.proto
+++ b/proto/wippersnapper/description/v1/description.proto
@@ -44,7 +44,7 @@ message CreateDescriptionResponse {
   int32 total_gpio_pins    = 2; /** Specifies the number of GPIO pins on the client's physical hardware. */
   int32 total_analog_pins  = 3; /** Specifies the number of analog pins on the client's physical hardware. */
   float reference_voltage  = 4; /** Specifies the hardware's default reference voltage. */
-  int32 total_i2c_buses    = 5; /** Specifies the number of hardware's I2C peripherals (i2cBus[]). */
+  int32 total_i2c_ports    = 5; /** Specifies the number of hardware's I2C ports (i2cPorts[]). */
 
   /**
    * Response. Specifies if the hardware definiton is within the database.


### PR DESCRIPTION
Adds the total number of i2c ports (specified by `i2cPorts` here: https://github.com/adafruit/Wippersnapper_Boards/pull/18/commits/9b618b004d5f6516791d84151eec624ee9bd62ae) to hardware registration response.