### PR TITLE
Redo I2C Scan, add init

### DIFF
--- a/proto/wippersnapper/i2c/v1/i2c.proto
+++ b/proto/wippersnapper/i2c/v1/i2c.proto
@@ -5,15 +5,21 @@ syntax = "proto3";
 package wippersnapper.i2c.v1;
 
 /**
-* I2CScanRequest represents the parameters of the I2C scan
-* performed by a device.
+* I2CInitRequest represents a request to
+* initialize an I2C Component.
 */
-message I2CScanRequest {
-  repeated uint32 address = 1 [packed=true]; /** The 7-bit I2C address for the device stored by IO. */
-  uint32 frequency = 2; /** The desired I2C SCL frequency, in Hz. Default is 100000Hz. */
-  int32 pin_scl  = 3; /** The desired I2C SCL pin. */
-  int32 pin_sda  = 4; /** The desired I2C SDA pin. */
-  int32 bus_id   = 5; /** An optional I2C bus identifier, if multiple exist. */
+message I2CInitRequest {
+  int32  i2c_pin_scl     = 1; /** The desired I2C SCL pin. */
+  int32  i2c_pin_sda     = 2; /** The desired I2C SDA pin. */
+  uint32 i2c_frequency   = 3; /** The desired I2C SCL frequency, in Hz. Default is 100000Hz. */
+  int32  i2c_port_number = 4; /** The I2C port number. */
+}
+
+/**
+* I2CInitResponse represents a response to I2CInitRequest
+*/
+message I2CInitResponse {
+  bool is_initialized = 1; /** True if the I2C port has been initialized successfully, False otherwise. */
 }
 
 /**
@@ -26,8 +32,15 @@ message I2CSetFrequency {
 }
 
 /**
-* I2CScanResponse represents the response of a call to
-* `Adafruit_I2CDevice::begin`.
+* I2CScanRequest represents the parameters required to perform
+* an I2C component's scan function.
+*/
+message I2CScanRequest {
+  repeated uint32 address = 1 [packed=true]; /** The 7-bit I2C address for the device stored by IO. */
+}
+
+/**
+* I2CScanResponse represents the response of an I2C component which finished executing an I2CScanRequest.
 */
 message I2CScanResponse {
   bool is_address_found = 1; /** True if an I2C address was found on the bus, False otherwise.. */

--- a/proto/wippersnapper/signal/v1/signal.proto
+++ b/proto/wippersnapper/signal/v1/signal.proto
@@ -14,29 +14,28 @@ import "wippersnapper/pixel/v1/pixel.proto";
 import "nanopb/nanopb.proto";
 
 /**
-* I2CRequest represents a request
-* for a device to perform an I2C command.
+* I2CRequest represents a request to an I2C component.
 */
 message I2CRequest {
   option (nanopb_msgopt).submsg_callback = true;
   oneof payload {
-    wippersnapper.i2c.v1.I2CScanRequest req_i2c_scan      = 1;
-    wippersnapper.i2c.v1.I2CSetFrequency req_i2c_set_freq = 2;
-    wippersnapper.i2c.v1.AHTInitRequest req_aht_init      = 3;
-    wippersnapper.i2c.v1.AHTDeinitRequest req_aht_deinit  = 4;
+    wippersnapper.i2c.v1.I2CInitRequest req_i2c_init      = 1;
+    wippersnapper.i2c.v1.I2CScanRequest req_i2c_scan      = 2;
+    wippersnapper.i2c.v1.I2CSetFrequency req_i2c_set_freq = 3;
+    wippersnapper.i2c.v1.AHTInitRequest req_aht_init      = 4;
+    wippersnapper.i2c.v1.AHTDeinitRequest req_aht_deinit  = 5;
   }
 }
 
 /**
-* I2CResponse represents a device's response to
-* Adafruit.io containing information about an I2C
-* command.
+* I2CResponse represents the response from an I2C component.
 */
 message I2CResponse {
   option (nanopb_msgopt).submsg_callback = true;
   oneof payload {
-    wippersnapper.i2c.v1.I2CScanResponse resp_i2c_scan = 1;
-    wippersnapper.i2c.v1.AHTInitResponse resp_aht_init = 2;
+    wippersnapper.i2c.v1.I2CInitResponse resp_i2c_init = 1;
+    wippersnapper.i2c.v1.I2CScanResponse resp_i2c_scan = 2;
+    wippersnapper.i2c.v1.AHTInitResponse resp_aht_init = 3;
   }
 }
 


### PR DESCRIPTION
As it stands in `master`, i2cscanrequest handles both i2c port initialization and scanning. This approach requires re-initialization and/or transmitting additional information about the bus. We should only be setting up I2C once (per port), not every scan.

This pull request breaks out i2c initialization parameters from an `I2CScanRequest` into an `I2CInitRequest`. 

In the new, modified, workflow:
* If the i2c port has been initialized (@lorennorman  the contents of `I2CInitRequest` should be stored in the DB), we skip this step and go directly to performing an `I2CScanRequest`
* If device's i2c port(s) have not been configured, we show a new "Initialize I2C Port" screen which allows the user to select the SCL/SDA lines from the hardware definition.
* An `I2CInitRequest` msg is sent to the device over the I2C MQTT topic. Broker waits for an `I2CInitResponse` message to be sent from the device, indicating the bus is configured properly.
 

Notes: Marked OK if this PR is failing, there are breaking API changes (not integrated yet into application-level code)