### PR TITLE
Add I2C Scan Response Address

### DIFF
--- a/proto/wippersnapper/i2c/v1/i2c.proto
+++ b/proto/wippersnapper/i2c/v1/i2c.proto
@@ -45,8 +45,7 @@ message I2CScanRequest {
 * I2CScanResponse represents the response of an I2C component which finished executing an I2CScanRequest.
 */
 message I2CScanResponse {
-  bool is_address_found       = 1; /** True if an I2C address was found on the bus, False otherwise.. */
-  uint32 which_address_found  = 2; /** The 7-bit I2C address of the device on the bus. */
+  uint32 address_found = 1; /** The 7-bit I2C address of the device on the bus, -1 if not found. */
 }
 
 // I2C Sensors, Unified API //


### PR DESCRIPTION
An `I2CScanRequest` message may send more than one `address` field. This pull request adds a `which_address_found` field to the device's `I2CScanResponse` to indicate which address contains an I2C device.