### PR TITLE
Revert "Add SensorEvent, I2C"

### DIFF
--- a/proto/wippersnapper/i2c/v1/i2c.proto
+++ b/proto/wippersnapper/i2c/v1/i2c.proto
@@ -218,14 +218,14 @@ message SensorDetails {
 }
 
 /**
-* SensorEvent is used to return sensor data from any sensor supported by the abstraction layer,
+* SensorEvent  is used to return sensor data from any sensor supported by the abstraction layer,
 * using standard SI units and scales.
 */
 message SensorEvent {
-  optional int32 version   = 1; /** Contain 'sizeof(sensors_event_t)' to identify which version of the API we're using in case this changes in the future */
-  optional int32 sensor_id = 2; /** A unique sensor identifier that is used to differentiate this specific sensor instance from any others that are present on the system or in the sensor network */
-  optional SensorType type = 3; /** The sensor type, based on SensorType */
-  optional int32 timestamp = 4; /** Time in milliseconds when the sensor value was read */
+  int32 version   = 1; /** Contain 'sizeof(sensors_event_t)' to identify which version of the API we're using in case this changes in the future */
+  int32 sensor_id = 2; /** A unique sensor identifier that is used to differentiate this specific sensor instance from any others that are present on the system or in the sensor network */
+  SensorType type = 3; /** The sensor type, based on SensorType */
+  int32 timestamp = 4; /** Time in milliseconds when the sensor value was read */
   oneof event_data {
     float temperature       = 5;
     float distance          = 6;
@@ -235,13 +235,4 @@ message SensorEvent {
     float current           = 10;
     float voltage           = 11;
   }
-}
-
-/**
-* I2CSensorEvent represents data from an I2C Sensor, including its address.
-* NOTE: In the future, we may want to pack repeated SensorEvents.
-*/
-message I2CSensorEvent {
-  uint32 sensor_address  = 1; /** The 7-bit I2C address of the device on the bus. */
-  SensorEvent event      = 2; /** A SensorEvent from the device. */
 }

--- a/proto/wippersnapper/signal/v1/signal.proto
+++ b/proto/wippersnapper/signal/v1/signal.proto
@@ -14,7 +14,7 @@ import "wippersnapper/pixel/v1/pixel.proto";
 import "nanopb/nanopb.proto";
 
 /**
-* I2CRequest represents a request from IO to an I2C component.
+* I2CRequest represents a request to an I2C component.
 */
 message I2CRequest {
   option (nanopb_msgopt).submsg_callback = true;
@@ -27,7 +27,7 @@ message I2CRequest {
 }
 
 /**
-* I2CResponse represents the response from a device's I2C component to IO.
+* I2CResponse represents the response from an I2C component.
 */
 message I2CResponse {
   option (nanopb_msgopt).submsg_callback = true;
@@ -35,16 +35,6 @@ message I2CResponse {
     wippersnapper.i2c.v1.I2CInitResponse resp_i2c_init = 1;
     wippersnapper.i2c.v1.I2CScanResponse resp_i2c_scan = 2;
     wippersnapper.i2c.v1.I2CDeviceInitResponse resp_i2c_device_init = 3;
-  }
-}
-
-/**
-* SensorEvent is used to return sensor data from any
-* sensor type supported by the Adafruit Sensor abstraction layer.
-*/
-message SensorEvent {
-  oneof event {
-    wippersnapper.i2c.v1.I2CSensorEvent i2c = 1; /** An I2C Sensor's SensorEvent */
   }
 }
 


### PR DESCRIPTION
Reverts adafruit/Wippersnapper_Protobuf#57 as "wippersnapper/i2c/v1/i2c.proto: This file contains proto3 optional fields, but --experimental_allow_proto3_optional was not set."

Will be fixed in subsequent PR