### PR TITLE
Add Sensor Event, I2C (2)

### DIFF
--- a/proto/wippersnapper/i2c/v1/i2c.proto
+++ b/proto/wippersnapper/i2c/v1/i2c.proto
@@ -236,3 +236,12 @@ message SensorEvent {
     float voltage           = 11;
   }
 }
+
+/**
+* I2CSensorEvent represents data from an I2C Sensor, including its address.
+* NOTE: In the future, we may want to pack repeated SensorEvents.
+*/
+message I2CSensorEvent {
+  uint32 sensor_address  = 1; /** The 7-bit I2C address of the device on the bus. */
+  SensorEvent event      = 2; /** A SensorEvent from the device. */
+} 

--- a/proto/wippersnapper/signal/v1/signal.proto
+++ b/proto/wippersnapper/signal/v1/signal.proto
@@ -14,7 +14,7 @@ import "wippersnapper/pixel/v1/pixel.proto";
 import "nanopb/nanopb.proto";
 
 /**
-* I2CRequest represents a request to an I2C component.
+* I2CRequest represents the broker's request for a specific i2c command to a device.
 */
 message I2CRequest {
   option (nanopb_msgopt).submsg_callback = true;
@@ -27,7 +27,7 @@ message I2CRequest {
 }
 
 /**
-* I2CResponse represents the response from an I2C component.
+* I2CResponse represents the device's response to an I2C-specific message from IO.
 */
 message I2CResponse {
   option (nanopb_msgopt).submsg_callback = true;
@@ -35,6 +35,16 @@ message I2CResponse {
     wippersnapper.i2c.v1.I2CInitResponse resp_i2c_init = 1;
     wippersnapper.i2c.v1.I2CScanResponse resp_i2c_scan = 2;
     wippersnapper.i2c.v1.I2CDeviceInitResponse resp_i2c_device_init = 3;
+  }
+}
+
+/**
+* SensorEvent is used to return sensor data from any
+* sensor type supported by the Adafruit Sensor abstraction layer.
+*/
+message SensorEvent {
+  oneof event {
+    wippersnapper.i2c.v1.I2CSensorEvent i2c = 1; /** An I2C Sensor's SensorEvent */
   }
 }
 


### PR DESCRIPTION
Mirror of https://github.com/adafruit/Wippersnapper_Protobuf/pull/57 except "I2C: Modifies SensorEvent generic's version, sensor_id, type, and timestamp to become optional fields" has been removed in favor of not using optional fields (Python protobuf. compiler does not have experimental support turned on)