### PR TITLE
Add I2C Device De-initialization Request/Response

### DIFF
--- a/proto/wippersnapper/i2c/v1/i2c.proto
+++ b/proto/wippersnapper/i2c/v1/i2c.proto
@@ -67,19 +67,19 @@ message I2CDeviceInitResponse {
 }
 
 /**
-* I2CDeviceDeInitRequest is a wrapper message containing
+* I2CDeviceDeinitRequest is a wrapper message containing
 * a deinitialization request for a specific i2c device.
 */
-message I2CDeviceDeInitRequest {
+message I2CDeviceDeinitRequest {
     int32  i2c_port_number  = 1; /** The desired I2C port to de-initialize an I2C device on. */
     AHTDeinitRequest aht    = 2; /** A request to de-initialize an AHTX0 i2c sensor. */
 }
 
 /**
-* I2CDeviceInitResponse represents if an I2C device's
+* I2CDeviceDeinitResponse represents if an I2C device's
 * sensor(s) is/are successfully de-initialized.
 */
-message I2CDeviceDeInitResponse {
+message I2CDeviceDeinitResponse {
     bool is_success = 1; /** True if the deinitialization request succeeded, False otherwise. */
 }
 

--- a/proto/wippersnapper/signal/v1/signal.proto
+++ b/proto/wippersnapper/signal/v1/signal.proto
@@ -23,7 +23,7 @@ message I2CRequest {
     wippersnapper.i2c.v1.I2CScanRequest req_i2c_scan                  = 2;
     wippersnapper.i2c.v1.I2CSetFrequency req_i2c_set_freq             = 3;
     wippersnapper.i2c.v1.I2CDeviceInitRequest req_i2c_device_init     = 4;
-    wippersnapper.i2c.v1.I2CDeviceDeInitRequest req_i2c_device_deinit = 5;
+    wippersnapper.i2c.v1.I2CDeviceDeinitRequest req_i2c_device_deinit = 5;
   }
 }
 
@@ -36,7 +36,7 @@ message I2CResponse {
     wippersnapper.i2c.v1.I2CInitResponse resp_i2c_init                  = 1;
     wippersnapper.i2c.v1.I2CScanResponse resp_i2c_scan                  = 2;
     wippersnapper.i2c.v1.I2CDeviceInitResponse resp_i2c_device_init     = 3;
-    wippersnapper.i2c.v1.I2CDeviceDeInitResponse resp_i2c_device_deinit = 4;
+    wippersnapper.i2c.v1.I2CDeviceDeinitResponse resp_i2c_device_deinit = 4;
   }
 }
 


### PR DESCRIPTION
I2C devices may expose one or more sensors. This pull request adds a new I2C wrapper message `I2CDeviceDeInitRequest` comprising of the i2c port # and de-initialization requests for specific i2c devices. This message request will be decoded by the main application and passed to the I2C component for exec.