### PR TITLE
Add detach option to I2CDeviceInitRequest

### DIFF
--- a/proto/wippersnapper/i2c/v1/i2c.proto
+++ b/proto/wippersnapper/i2c/v1/i2c.proto
@@ -54,9 +54,8 @@ message I2CScanResponse {
 */
 message I2CDeviceInitRequest {
     int32  i2c_port_number        = 1; /** The desired I2C port to initialize an I2C device on. */
-    bool   detach_device          = 2; /** A request to stop polling the i2c device and free its driver. */
-    AHTInitRequest aht_init       = 3; /** A request to initialize an AHTX0 i2c sensor device. */
-    DPS310InitRequest dps310_init = 4; /** A request to initialize an DPS310 i2c sensor device. */
+    AHTInitRequest aht_init       = 2; /** A request to initialize an AHTX0 i2c sensor device. */
+    DPS310InitRequest dps310_init = 3; /** A request to initialize an DPS310 i2c sensor device. */
 }
 
 /**
@@ -72,9 +71,10 @@ message I2CDeviceInitResponse {
 * a deinitialization request for a specific i2c device.
 */
 message I2CDeviceDeinitRequest {
-    int32  i2c_port_number  = 1; /** The desired I2C port to de-initialize an I2C device on. */
-    uint32 address          = 2; /** The 7-bit I2C address of the device on the bus. */
-    AHTDeinitRequest aht    = 3; /** A request to de-initialize an AHTX0 i2c sensor. */
+    int32  i2c_port_number        = 1; /** The desired I2C port to de-initialize an I2C device on. */
+    uint32 address                = 2; /** The 7-bit I2C address of the device on the bus. */
+    bool   detach_device          = 3; /** If true, stop polling the i2c device and free its driver. */
+    AHTDeinitRequest aht          = 4; /** A request to de-initialize an AHTX0 i2c sensor. */
 }
 
 /**


### PR DESCRIPTION
Instead of checking the parameters inside each device-specific deinit request, allow an I2C_Component to remove the I2C device driver from a vector and free its resources. 