### PR TITLE
Add message for Adafruit STEMMA Soil Sensor

### DIFF
--- a/proto/wippersnapper/i2c/v1/i2c.proto
+++ b/proto/wippersnapper/i2c/v1/i2c.proto
@@ -254,7 +254,7 @@ enum SensorType {
   SENSOR_TYPE_VOLTAGE             = 15;
   SENSOR_TYPE_CURRENT             = 16;
   SENSOR_TYPE_COLOR               = 17;
-  SENSOR_TYPE_CAPTOUCH_RAW        = 18;
+  SENSOR_TYPE_RAW                 = 18;
 }
 
 /**
@@ -288,7 +288,7 @@ message SensorEvent {
     float relative_humidity = 9;
     float current           = 10;
     float voltage           = 11;
-    uint32 raw_captouch     = 12; /** Raw capactive touch measurement. */
+    uint32 raw_value        = 12;
   }
 }
 


### PR DESCRIPTION
- Add message for [Adafruit STEMMA Soil Sensor - I2C Capacitive Moisture Sensor](https://www.adafruit.com/product/4026). 
- Add new `SENSOR_TYPE_CAPTOUCH_RAW` enum for a raw capacitive touch sensor (sends as int).
  - If a capacitive-touch sensor is being polled for a sensor-event, the `SensorEvent`'s `raw_captouch` field will be set.
  - NOTE: This is a unit-less `SENSOR_TYPE` as it's a raw value.