### PR TITLE
Update I2CDevice Initialization Messages

### DIFF
--- a/proto/wippersnapper/i2c/v1/i2c.proto
+++ b/proto/wippersnapper/i2c/v1/i2c.proto
@@ -54,9 +54,9 @@ message I2CScanResponse {
 */
 message I2CDeviceInitRequest {
   int32  i2c_port_number                 = 1; /** The desired I2C port to initialize an I2C device on. */
-  AHTInitRequest aht_init                = 2; /** A request to initialize an AHTX0 i2c sensor device. */
-  DPS310InitRequest dps310_init          = 3; /** A request to initialize a DPS310 i2c sensor device. */
-  SeesawInitRequest seesaw_init          = 4; /** A request to initialize a SeeSaw device. */
+  uint32 i2c_address                     = 2; /** The 7-bit I2C address of the device on the bus. */
+  AHTInitRequest aht_init                = 3; /** A request to initialize an AHTX0 i2c sensor device. */
+  DPS310InitRequest dps310_init          = 4; /** A request to initialize a DPS310 i2c sensor device. */
 }
 
 /**
@@ -73,11 +73,10 @@ message I2CDeviceInitResponse {
 */
 message I2CDeviceDeinitRequest {
     int32  i2c_port_number        = 1; /** The desired I2C port to de-initialize an I2C device on. */
-    uint32 address                = 2; /** The 7-bit I2C address of the device on the bus. */
+    uint32 i2c_address            = 2; /** The 7-bit I2C address of the device on the bus. */
     bool   detach_device          = 3; /** If true, stop polling the i2c device and free its driver. */
     AHTDeinitRequest aht          = 4; /** A request to de-initialize an AHTX0 sensor. */
     DPS310DeinitRequest dps       = 5; /** A request to de-initialize a DPS310 sensor. */
-    SeesawDeinitRequest seesaw    = 6; /** A request to de-initialize a SeeSaw device's sensor. */
 }
 
 /**
@@ -85,7 +84,8 @@ message I2CDeviceDeinitRequest {
 * sensor(s) is/are successfully de-initialized.
 */
 message I2CDeviceDeinitResponse {
-    bool is_success = 1; /** True if the deinitialization request succeeded, False otherwise. */
+    bool is_success     = 1; /** True if the deinitialization request succeeded, False otherwise. */
+    uint32 i2c_address  = 2; /** The 7-bit I2C address of the device which was initialized. */
 }
 
 // Device-specific //
@@ -94,10 +94,10 @@ message I2CDeviceDeinitResponse {
 * an AHTX0 temperature/humidity sensor.
 */
 message AHTInitRequest {
-  bool enable_temperature = 1; /** True if AHTX0 expects to init. the temperature data object, False otherwise. */
-  bool enable_humidity    = 2; /** True if AHTX0 expects to init. the humidity data object, False otherwise. */
-  float period            = 3; /** Specifies the time between measurements, in seconds. */
-  uint32 address          = 4; /** The 7-bit I2C address of the device on the bus. */
+  bool enable_temperature  = 1; /** True if AHTX0 expects to init. the temperature data object, False otherwise. */
+  float period_temperature = 2; /** Specifies the time between temperature sensor measurements, in seconds. */
+  bool enable_humidity     = 3; /** True if AHTX0 expects to init. the humidity data object, False otherwise. */
+  float period_humidity    = 4; /** Specifies the time between humidity sensor measurements, in seconds. */
 }
 
 /**
@@ -111,16 +111,13 @@ message AHTDeinitRequest {
 
 /**
 * DPS310 represents the request to initialize
-* a DPS310 Precision Barometric Pressure and Altitude Sensor
-* NOTE: This RPC also implements the following calls, in addition to begin():
-* dps.configurePressure(DPS310_64HZ, DPS310_64SAMPLES);
-* dps.configureTemperature(DPS310_64HZ, DPS310_64SAMPLES);
+* a DPS310 Precision Barometric Pressure and Altitude Sensor.
 */
 message DPS310InitRequest {
-  bool enable_temperature = 1; /** True if DPS310 expects to init. the temperature data object, False otherwise. */
-  bool enable_pressure    = 2; /** True if DPS310 expects to init. the pressure data object, False otherwise. */
-  float period            = 3; /** Specifies the time between measurements, in seconds. */
-  uint32 address          = 4; /** The 7-bit I2C address of the device on the bus. */
+  bool enable_temperature  = 1; /** True if DPS310 expects to init. the temperature data object, False otherwise. */
+  float period_temperature = 2; /** Specifies the time between temperature sensor measurements, in seconds. */
+  bool enable_pressure     = 3; /** True if DPS310 expects to init. the pressure data object, False otherwise. */
+  float period_pressure    = 4; /** Specifies the time between pressure sensor measurements, in seconds. */
 }
 
 /**
@@ -132,105 +129,6 @@ message DPS310DeinitRequest {
   bool disable_temperature  = 2; /** True to disable the DPS310's humidity sensor. */
 }
 
-/**
-* SeesawInitRequest represents a request to initialize
-* an Adafruit SeeSaw device.
-*/
-message SeesawInitRequest {
-  uint32 address          = 1; /** The 7-bit I2C address of the device on the bus. */
-  float period            = 2; /** Specifies the time between measurements, in seconds. */
-  bool enable_temperature = 3; /** True to enable the SeeSaw's temperature sensor (if applicable on firmware) */
-  bool enable_touch_read  = 4; /** True to enable reading (polling) a SeeSaw's capacitive touch pin. */
-  uint32 touch_pin        = 5; /** If enable_touch_read, the number of the capactive touch pin to read. */
-}
-
-/**
-* SeesawDeinitRequest represents a request to de-initialize
-* an Adafruit SeeSaw device.
-*/
-message SeesawDeinitRequest {
-  bool disable_temperature = 1; /** True to disable the SeeSaw's temperature sensor. */
-  bool disable_touch_read  = 2; /** True to disable the SeeSaw's capacitive touch sensor. */
-  uint32 touch_pin         = 3; /** If disable_touch_read, the number of the capactive touch pin to disable. */
-}
-
-/**
-* SHT4X represents the request to initialize
-* a Sensirion SHT40 Temperature & Humidity Sensor
-*/
-message SHT4XInitRequest {
-  bool enable_temperature      = 1; /** True if SHT4X expects to init. the temperature data object, False otherwise. */
-  bool enable_humidity         = 2; /** True if SHT4X expects to init. the humidity data object, False otherwise. */
-  float period                 = 4; /** Specifies the time between measurements, in seconds. */
-  SHT4XHEATERMODE heater_mode  = 5; /** Heater mode. */
-  SHT4XPRECISION precision     = 6; /** SHT4X reading precision. */
-  uint32 address               = 7; /** The 7-bit I2C address of the device on the bus. */
-
-  /** SHT4X Precision Mode */
-  enum SHT4XPRECISION {
-    SHT4XPRECISION_UNSPECIFIED = 0;
-    SHT4XPRECISION_HIGH        = 1;
-    SHT4XPRECISION_MED         = 2;
-    SHT4XPRECISION_LOW         = 3;
-  }
-
-  /** SHT4X Heater Mode */
-  enum SHT4XHEATERMODE {
-    SHT4XHEATERMODE_UNSPECIFIED       = 0;
-    SHT4XHEATERMODE_NO_HEATER         = 1;
-    SHT4XHEATERMODE_HIGH_HEATER_1S    = 2;
-    SHT4XHEATERMODE_HIGH_HEATER_100MS = 3;
-    SHT4XHEATERMODE_MED_HEATER_1S     = 4;
-    SHT4XHEATERMODE_MED_HEATER_100MS  = 5;
-    SHT4XHEATERMODE_LOW_HEATER_1S     = 6;
-    SHT4XHEATERMODE_LOW_HEATER_100MS  = 7;
-  }
-}
-
-
-// Non-Unified API Sensors //
-
-/**
-* SCD30InitRequest represents the request to initialize
-* a SCD30 CO2 Temperature and Humidity Sensor.
-*/
-message SCD30InitRequest {
-  bool enable_temperature    = 1; /** True if SCD30 expects to init. the temperature data object, False otherwise. */
-  bool enable_rel_humidity   = 2; /** True if SCD30 expects to init. the relative humidity data object, False otherwise. */
-  bool enable_c02            = 3; /** True if SCD30 expects to init. the CO2 data object, False otherwise. */
-  float period               = 4; /** Specifies the time between measurements, in seconds. */
-  float measurement_interval = 5; /** Set the amount of time between measurements, in seconds. Must be from 2-1800 seconds. Defaults to 2 seconds. */
-  uint32 address             = 6; /** The 7-bit I2C address of the device on the bus. */
-}
-
-
-/**
-* SCD30InitResponse represents the response from each
-* property of a SCD30 object after a read() event.
-*/
-message SCD30ReadEvent {
-    float c_o2              = 1; /** The most recent CO2 reading */
-    float temperature       = 2; /** The most recent temperature reading */
-    float relative_humidity = 3; /** The most recent relative humidity reading */
-}
-
-/**
-* BH1750InitRequest represents the request to initialize
-* a BH1750 Ambient Light Sensor.
-*/
-message BH1750InitRequest {
-  bool enable_lux = 1; /** True if BH1750 expects to init. the lux data object, False otherwise. Defaults to True. */
-  float period    = 2; /** Specifies the time between measurements, in seconds. */
-  uint32 address  = 3; /** The 7-bit I2C address of the device on the bus. */
-}
-
-/**
-* BH1750ReadEvent represents the response from each
-* property of a BH1750 object after a `getLux()` event.
-*/
-message BH1750ReadEvent {
-    float lux              = 1; /** The most recent lux value. */
-}
 
 /** Adafruit Unified Sensor Library Messages. */
 


### PR DESCRIPTION
Updates I2CDevice Initialization messages
* DeInitialization msgs contain the unique i2c addr.
* Initialization msgs contain the unique i2c addr, instead of the sub-msg.
* `period_propertyName` added to each individual sensor, instead of the device as a whole
* Remove unused/old DeviceRequests from prototyping to reduce compiled file size.