### PR TITLE
BREAKING: Modify I2C Bus Messages

### DIFF
--- a/proto/wippersnapper/i2c/v1/i2c.proto
+++ b/proto/wippersnapper/i2c/v1/i2c.proto
@@ -6,10 +6,10 @@ package wippersnapper.i2c.v1;
 import "nanopb/nanopb.proto";
 
 /**
-* I2CInitRequest represents a request to
+* I2CBusInitRequest represents a request to
 * initialize an I2C Component.
 */
-message I2CInitRequest {
+message I2CBusInitRequest {
   int32  i2c_pin_scl     = 1; /** The desired I2C SCL pin. */
   int32  i2c_pin_sda     = 2; /** The desired I2C SDA pin. */
   uint32 i2c_frequency   = 3; /** The desired I2C SCL frequency, in Hz. Default is 100000Hz. */
@@ -17,34 +17,34 @@ message I2CInitRequest {
 }
 
 /**
-* I2CInitResponse represents a response to I2CInitRequest
+* I2CBusInitResponse represents a response to I2CBusInitRequest
 */
-message I2CInitResponse {
+message I2CBusInitResponse {
   bool is_initialized = 1; /** True if the I2C port has been initialized successfully, False otherwise. */
 }
 
 /**
-* I2CSetFrequency represents a request to change the
+* I2CBusSetFrequency represents a request to change the
 * I2C clock speed to a desired frequency, in Hz.
 */
-message I2CSetFrequency {
+message I2CBusSetFrequency {
   uint32 frequency = 1; /** The desired I2C SCL frequency, in Hz. */
   int32 bus_id     = 2; /** An optional I2C bus identifier, if multiple exist. */
 }
 
 /**
-* I2CScanRequest represents the parameters required to execute
+* I2CBusScanRequest represents the parameters required to execute
 * a device's I2C scan.
 */
-message I2CScanRequest {
+message I2CBusScanRequest {
   int32  i2c_port_number  = 1; /** The desired I2C port to scan. */
 }
 
 /**
-* I2CScanResponse represents a list of I2C addresses
-* found on the bus after I2CScanRequest has executed.
+* I2CBusScanResponse represents a list of I2C addresses
+* found on the bus after I2CBusScanRequest has executed.
 */
-message I2CScanResponse {
+message I2CBusScanResponse {
   repeated uint32 addresses_found = 1 [packed=true, (nanopb).max_count = 120]; /** The 7-bit addresses of the I2C devices found on the bus, empty if not found. */
 }
 

--- a/proto/wippersnapper/signal/v1/signal.proto
+++ b/proto/wippersnapper/signal/v1/signal.proto
@@ -17,9 +17,9 @@ import "wippersnapper/i2c/v1/i2c.proto";
 message I2CRequest {
   option (nanopb_msgopt).submsg_callback = true;
   oneof payload {
-    wippersnapper.i2c.v1.I2CInitRequest req_i2c_init                  = 1;
-    wippersnapper.i2c.v1.I2CScanRequest req_i2c_scan                  = 2;
-    wippersnapper.i2c.v1.I2CSetFrequency req_i2c_set_freq             = 3;
+    wippersnapper.i2c.v1.I2CBusInitRequest req_i2c_init                  = 1;
+    wippersnapper.i2c.v1.I2CBusScanRequest req_i2c_scan                  = 2;
+    wippersnapper.i2c.v1.I2CBusSetFrequency req_i2c_set_freq             = 3;
     wippersnapper.i2c.v1.I2CDeviceInitRequest req_i2c_device_init     = 4;
     wippersnapper.i2c.v1.I2CDeviceDeinitRequest req_i2c_device_deinit = 5;
   }
@@ -31,8 +31,8 @@ message I2CRequest {
 message I2CResponse {
   option (nanopb_msgopt).submsg_callback = true;
   oneof payload {
-    wippersnapper.i2c.v1.I2CInitResponse resp_i2c_init                  = 1;
-    wippersnapper.i2c.v1.I2CScanResponse resp_i2c_scan                  = 2;
+    wippersnapper.i2c.v1.I2CBusInitResponse resp_i2c_init                  = 1;
+    wippersnapper.i2c.v1.I2CBusScanResponse resp_i2c_scan                  = 2;
     wippersnapper.i2c.v1.I2CDeviceInitResponse resp_i2c_device_init     = 3;
     wippersnapper.i2c.v1.I2CDeviceDeinitResponse resp_i2c_device_deinit = 4;
   }
@@ -63,7 +63,7 @@ message CreateSignalRequest {
     wippersnapper.pin.v1.PinEvents pin_events                           = 7;
     // I2C Sensor API, !DEPRECATED! //
     // Initiates an RPC to scan an I2C bus for a specific I2C bus address
-    wippersnapper.i2c.v1.I2CScanRequest request_i2c_scan                = 16 [deprecated = true, (nanopb).type = FT_IGNORE];
+    wippersnapper.i2c.v1.I2CBusScanRequest request_i2c_scan                = 16 [deprecated = true, (nanopb).type = FT_IGNORE];
     // Sensor-specific APIs
     // Initialize an AHTX0 sensor
     wippersnapper.i2c.v1.AHTInitRequest request_aht_init                = 17 [deprecated = true, (nanopb).type = FT_IGNORE];


### PR DESCRIPTION
This pull request is **BREAKING** for production code. 

* Renames commands involving the I2C bus to `I2CBusCommandName` to reflect they are addressing the I2C bus component, rather than the I2C device driver.