### PR TITLE
Add max_count to the sensor events

### DIFF
--- a/proto/wippersnapper/i2c/v1/i2c.proto
+++ b/proto/wippersnapper/i2c/v1/i2c.proto
@@ -171,5 +171,5 @@ message SensorEvent {
 */
 message I2CDeviceEvent {
   uint32 sensor_address              = 1; /** The 7-bit I2C address of the I2C device. */
-  repeated SensorEvent sensor_event  = 2; /** A, optionally repeated, SensorEvent from a sensor. */
-} 
+  repeated SensorEvent sensor_event  = 2[(nanopb).max_count = 15]; /** A, optionally repeated, SensorEvent from a sensor. */
+}


### PR DESCRIPTION
Adding `max_count` nanopb compiler flag to the `SensorEvent` to assist with encoding.


Moves away from a callback encoding model (we did not get this working last time) to compiling the senor_event as an array of sensor_event structs.

Example C++ code:
```
// Pack SensorEvent payload              

msgi2cResponse.payload.resp_i2c_device_event.sensor_event[msgi2cResponse.payload.resp_i2c_device_event.sensor_event_count].type = wippersnapper_i2c_v1_SensorType_SENSOR_TYPE_AMBIENT_TEMPERATURE;
              msgi2cResponse.payload.resp_i2c_device_event.sensor_event[msgi2cResponse.payload.resp_i2c_device_event.sensor_event_count].value = temp;
// Increment counter
msgi2cResponse.payload.resp_i2c_device_event.sensor_event_count++;
```