### PR TITLE
Enhance BusInitResponse error messages

### DIFF
--- a/proto/wippersnapper/i2c/v1/i2c.proto
+++ b/proto/wippersnapper/i2c/v1/i2c.proto
@@ -20,7 +20,14 @@ message I2CBusInitRequest {
 * I2CBusInitResponse represents a response to I2CBusInitRequest
 */
 message I2CBusInitResponse {
-  bool is_initialized = 1; /** True if the I2C port has been initialized successfully, False otherwise. */
+  enum BusResponse {
+    BUS_RESPONSE_UNSPECIFIED   = 0; /** Unspecified error occurred. **/
+    BUS_RESPONSE_SUCCESS       = 1; /** I2C bus successfully initialized. **/
+    BUS_RESPONSE_ERROR_HANG    = 2; /** I2C bus failed to initialize - I2C Bus hang, user should reset their board if this persists. **/
+    BUS_RESPONSE_ERROR_PULLUPS = 3; /** I2C bus failed to initialize - SDA or SCL needs a pull up. **/
+  }
+  bool is_initialized  = 1 [deprecated = true, (nanopb).type = FT_IGNORE]; /** True if the I2C port has been initialized successfully, False otherwise. */
+  BusResponse response = 2; /** Whether the I2C bus initialized properly or failed. **/
 }
 
 /**

--- a/proto/wippersnapper/i2c/v1/i2c.proto
+++ b/proto/wippersnapper/i2c/v1/i2c.proto
@@ -53,8 +53,8 @@ message I2CBusScanRequest {
 * found on the bus after I2CBusScanRequest has executed.
 */
 message I2CBusScanResponse {
-  repeated uint32 addresses_found       = 1 [packed=true, (nanopb).max_count = 120]; /** The 7-bit addresses of the I2C devices found on the bus, empty if not found. */
-  I2CBusInitResponse bus_init_response  = 2; /** Whether the I2C bus has been initialized successfully. */
+  repeated uint32 addresses_found  = 1 [packed=true, (nanopb).max_count = 120]; /** The 7-bit addresses of the I2C devices found on the bus, empty if not found. */
+  I2CBusInitResponse bus_response  = 2; /** Whether the I2C bus has been initialized successfully. */
 }
 
 /**

--- a/proto/wippersnapper/i2c/v1/i2c.proto
+++ b/proto/wippersnapper/i2c/v1/i2c.proto
@@ -6,6 +6,16 @@ package wippersnapper.i2c.v1;
 import "nanopb/nanopb.proto";
 
 /**
+* BusResponse represents the I2C bus status.
+*/
+enum BusResponse {
+  BUS_RESPONSE_UNSPECIFIED   = 0; /** Unspecified error occurred. **/
+  BUS_RESPONSE_SUCCESS       = 1; /** I2C bus successfully initialized. **/
+  BUS_RESPONSE_ERROR_HANG    = 2; /** I2C Bus hang, user should reset their board if this persists. **/
+  BUS_RESPONSE_ERROR_PULLUPS = 3; /** I2C bus failed to initialize - SDA or SCL needs a pull up. **/
+}
+
+/**
 * I2CBusInitRequest represents a request to
 * initialize the I2C bus.
 */
@@ -20,12 +30,6 @@ message I2CBusInitRequest {
 * I2CBusInitResponse represents a response to I2CBusInitRequest
 */
 message I2CBusInitResponse {
-  enum BusResponse {
-    BUS_RESPONSE_UNSPECIFIED   = 0; /** Unspecified error occurred. **/
-    BUS_RESPONSE_SUCCESS       = 1; /** I2C bus successfully initialized. **/
-    BUS_RESPONSE_ERROR_HANG    = 2; /** I2C bus failed to initialize - I2C Bus hang, user should reset their board if this persists. **/
-    BUS_RESPONSE_ERROR_PULLUPS = 3; /** I2C bus failed to initialize - SDA or SCL needs a pull up. **/
-  }
   bool is_initialized  = 1 [deprecated = true, (nanopb).type = FT_IGNORE]; /** True if the I2C port has been initialized successfully, False otherwise. */
   BusResponse response = 2; /** Whether the I2C bus initialized properly or failed. **/
 }
@@ -54,7 +58,7 @@ message I2CBusScanRequest {
 */
 message I2CBusScanResponse {
   repeated uint32 addresses_found  = 1 [packed=true, (nanopb).max_count = 120]; /** The 7-bit addresses of the I2C devices found on the bus, empty if not found. */
-  I2CBusInitResponse bus_response  = 2; /** Whether the I2C bus has been initialized successfully. */
+  BusResponse     bus_response     = 2; /** Whether the I2C initialization and transaction succeeded or failed. **/
 }
 
 /**


### PR DESCRIPTION
* Adds new `BusResponse response` field to `I2CBusInitResponse` to push messages about why the bus didn't successfully initialize to the broker for display on the frontend. Error message details are indicated in the comments.
* **deprecates** `is_initialized` field