### PR TITLE
Add message for Adafruit_PM25AQI

### DIFF
--- a/proto/wippersnapper/i2c/v1/i2c.proto
+++ b/proto/wippersnapper/i2c/v1/i2c.proto
@@ -74,6 +74,7 @@ message I2CDeviceInitRequest {
   DPS310UpdateRequest dps            = 5; /** A request to configure a DPS310 sensor. */
   SCD30UpdateRequest scd30           = 6; /** A request to initialize a SCD-30 sensor. */
   SCD4XUpdateRequest scd4x           = 7; /** A request to initialize a SCD4x sensor. */
+  PM25UpdateRequest pm25             = 8; /** A request to initialize a PM25 AQI sensor. */
 }
 
 /**
@@ -93,10 +94,11 @@ message I2CDeviceInitResponse {
 message I2CDeviceUpdateRequest {
     int32  i2c_port_number    = 1; /** The desired I2C port. */
     uint32 i2c_address        = 2; /** The 7-bit I2C address of the device on the bus. */
-    AHTUpdateRequest aht      = 3; /** A request to update the properties of an AHTX0. */
-    DPS310UpdateRequest dps   = 4; /** A request to update the properties of a DPS310. */
-    SCD30UpdateRequest scd30  = 5; /** A request to update the properties of a SCD-30. */
-    SCD4XUpdateRequest scd4x  = 6; /** A request to update the properties of a SCD4x. */
+    AHTUpdateRequest aht      = 3; /** A request to update the properties of an AHTX0 sensor. */
+    DPS310UpdateRequest dps   = 4; /** A request to update the properties of a DPS310 sensor. */
+    SCD30UpdateRequest scd30  = 5; /** A request to update the properties of a SCD-30 sensor. */
+    SCD4XUpdateRequest scd4x  = 6; /** A request to update the properties of a SCD4x sensor. */
+    PM25UpdateRequest pm25    = 7; /** A request to update the properties of a PM25 AQI sensor. */
 }
 
 /**
@@ -174,6 +176,24 @@ message SCD4XUpdateRequest {
   float period_humidity     = 4; /** Specifies the time between humidity sensor measurements, in seconds. */
   bool enable_co2           = 5; /** True to enable the SCD4X's CO2 sensor, False to disable. */
   float period_co2          = 6; /** Specifies the time between CO2 sensor measurements, in seconds. */
+}
+
+/**
+* PM25UpdateRequest represents the request to update or configure a PM25 AQ sensor.
+*/
+message PM25UpdateRequest {
+  bool enable_pm10_std   = 1; /** True to enable reading Standard PM1.0, False otherwise. */
+  float period_pm10_std  = 2;
+  bool enable_pm25_std   = 3; /** True to enable reading Standard PM2.5, False otherwise. */
+  float period_pm25_std  = 4;
+  bool enable_pm100_std  = 5; /** True to enable reading Standard PM10.0, False otherwise. */
+  float period_pm100_std = 6;
+  bool enable_pm10_env   = 7; /** True to enable reading Environmental PM1.0, False otherwise. */
+  float period_pm10_env  = 8;
+  bool enable_pm25_env   = 9; /** True to enable reading Environmental PM2.5, False otherwise. */
+  float period_pm25_env  = 10;
+  bool enable_pm100_env  = 11; /** True to enable reading Environmental PM10.0, False otherwise. */
+  float period_pm100_env = 12;
 }
 
 /** Adafruit Unified Sensor Library Messages. */


### PR DESCRIPTION
Types already added via moving selected `PMSAQIdata` members into SensorType fields.