### PR TITLE
Make I2C sensor messages more generic, reduce maintenance overhead

### DIFF
--- a/proto/wippersnapper/i2c/v1/i2c.proto
+++ b/proto/wippersnapper/i2c/v1/i2c.proto
@@ -63,17 +63,24 @@ message I2CBusScanResponse {
 }
 
 /**
+* I2CDeviceSensorProperties contains the type and period
+* of an I2C device's sensor.
+*/
+message I2CDeviceSensorProperties {
+  SensorType sensor_type = 1;
+  float sensor_period    = 2;
+}
+
+/**
 * I2CDeviceInitRequest is a wrapper message containing
 * an i2c-device-specific initialization request.
 */
 message I2CDeviceInitRequest {
-  int32  i2c_port_number             = 1; /** The desired I2C port to initialize an I2C device on. */
-  uint32 i2c_address                 = 2; /** The 7-bit I2C address of the device on the bus. */
-  I2CBusInitRequest bus_init_request = 3; /** An I2C bus initialization request. */
-  AHTUpdateRequest aht               = 4; /** A request to configure an AHTX0 sensor. */
-  DPS310UpdateRequest dps            = 5; /** A request to configure a DPS310 sensor. */
-  SCD30UpdateRequest scd30           = 6; /** A request to initialize a SCD-30 sensor. */
-  SCD4XUpdateRequest scd4x           = 7; /** A request to initialize a SCD4x sensor. */
+  int32  i2c_port_number                                    = 1; /** The desired I2C port to initialize an I2C device on. */
+  I2CBusInitRequest i2c_bus_init_req                        = 2; /** An I2C bus initialization request. */
+  uint32 i2c_device_address                                 = 3; /** The 7-bit I2C address of the device on the bus. */
+  string i2c_device_name                                    = 4; /** The I2C device's name, MUST MATCH the name on the JSON file. */
+  repeated I2CDeviceSensorProperties i2c_device_properties  = 5[(nanopb).max_count = 15]; /** Properties for the I2C device's sensors. */
 }
 
 /**
@@ -91,12 +98,10 @@ message I2CDeviceInitResponse {
 * a update request for a specific i2c device.
 */
 message I2CDeviceUpdateRequest {
-    int32  i2c_port_number    = 1; /** The desired I2C port. */
-    uint32 i2c_address        = 2; /** The 7-bit I2C address of the device on the bus. */
-    AHTUpdateRequest aht      = 3; /** A request to update the properties of an AHTX0. */
-    DPS310UpdateRequest dps   = 4; /** A request to update the properties of a DPS310. */
-    SCD30UpdateRequest scd30  = 5; /** A request to update the properties of a SCD-30. */
-    SCD4XUpdateRequest scd4x  = 6; /** A request to update the properties of a SCD4x. */
+    int32  i2c_port_number                                    = 1; /** The desired I2C port. */
+    uint32 i2c_address                                        = 2; /** The 7-bit I2C address of the device on the bus. */
+    string i2c_device_name                                    = 3; /** The I2C device's name, MUST MATCH the name on the JSON file. */
+    repeated I2CDeviceSensorProperties i2c_device_properties  = 4[(nanopb).max_count = 15]; /** Properties for the I2C device's sensors. */
 }
 
 /**
@@ -125,55 +130,6 @@ message I2CDeviceDeinitRequest {
 message I2CDeviceDeinitResponse {
     bool is_success     = 1; /** True if the deinitialization request succeeded, False otherwise. */
     uint32 i2c_address  = 2; /** The 7-bit I2C address of the device which was initialized. */
-}
-
-// Device-specific //
-
-/**
-* AHTUpdateRequest represents the request to update or configure
-* an AHTX0 temperature/humidity sensor.
-*/
-message AHTUpdateRequest {
-  bool enable_temperature  = 1; /** True to enable the temperature sensor, False to disable. */
-  float period_temperature = 2; /** Specifies the time between temperature sensor measurements, in seconds. */
-  bool enable_humidity     = 3; /** True to enable the humidity sensor, False to disable. */
-  float period_humidity    = 4; /** Specifies the time between humidity sensor measurements, in seconds. */
-}
-
-/**
-* DPS310UpdateRequest represents the request to update or configure
-* a DPS310 barometric pressure and altitude sensor.
-*/
-message DPS310UpdateRequest {
-  bool enable_pressure      = 1; /** True to enable the DPS310's pressure sensor, False to disable. */
-  float period_pressure     = 2; /** Specifies the time between pressure sensor measurements, in seconds. */
-  bool enable_temperature   = 3; /** True to enable the DPS310's temperature sensor, False to disable. */
-  float period_temperature  = 4; /** Specifies the time between temperature sensor measurements, in seconds. */
-}
-
-/**
-* SCD30UpdateRequest represents the request to update or configure
-* a SCD-30 NDIR CO2 Temperature and Humidity Sensor.
-*/
-message SCD30UpdateRequest {
-  bool enable_temperature   = 1; /** True to enable the SCD30's temperature sensor, False to disable. */
-  float period_temperature  = 2; /** Specifies the time between temperature sensor measurements, in seconds. */
-  bool enable_humidity      = 3; /** True to enable the SCD30's humidity sensor, False to disable. */
-  float period_humidity     = 4; /** Specifies the time between humidity sensor measurements, in seconds. */
-  bool enable_co2           = 5; /** True to enable the SCD30's CO2 sensor, False to disable. */
-  float period_co2          = 6; /** Specifies the time between CO2 sensor measurements, in seconds. */
-}
-
-/**
-* SCD4XUpdateRequest represents the request to update or configure a SCD4X sensor.
-*/
-message SCD4XUpdateRequest {
-  bool enable_temperature   = 1; /** True to enable the SCD4X's temperature sensor, False to disable. */
-  float period_temperature  = 2; /** Specifies the time between temperature sensor measurements, in seconds. */
-  bool enable_humidity      = 3; /** True to enable the SCD4X's humidity sensor, False to disable. */
-  float period_humidity     = 4; /** Specifies the time between humidity sensor measurements, in seconds. */
-  bool enable_co2           = 5; /** True to enable the SCD4X's CO2 sensor, False to disable. */
-  float period_co2          = 6; /** Specifies the time between CO2 sensor measurements, in seconds. */
 }
 
 /** Adafruit Unified Sensor Library Messages. */

--- a/proto/wippersnapper/i2c/v1/i2c.proto
+++ b/proto/wippersnapper/i2c/v1/i2c.proto
@@ -59,7 +59,7 @@ message I2CBusScanRequest {
 */
 message I2CBusScanResponse {
   repeated uint32 addresses_found  = 1 [packed=true, (nanopb).max_count = 120]; /** The 7-bit addresses of the I2C devices found on the bus, empty if not found. */
-    BusResponse bus_response       = 2; /** The I2C bus' status. **/
+  BusResponse bus_response       = 2; /** The I2C bus' status. **/
 }
 
 /**
@@ -88,9 +88,9 @@ message I2CDeviceInitRequest {
 * is successfully initialized by the client.
 */
 message I2CDeviceInitResponse {
-    bool is_success             = 1; /** True if i2c device initialized successfully, false otherwise. */
-    uint32 i2c_address          = 2; /** The 7-bit I2C address of the device on the bus. */
-    BusResponse bus_response    = 3; /** The I2C bus' status. **/
+  bool is_success             = 1; /** True if i2c device initialized successfully, false otherwise. */
+  uint32 i2c_address          = 2; /** The 7-bit I2C address of the device on the bus. */
+  BusResponse bus_response    = 3; /** The I2C bus' status. **/
 }
 
 /**
@@ -98,10 +98,10 @@ message I2CDeviceInitResponse {
 * a update request for a specific i2c device.
 */
 message I2CDeviceUpdateRequest {
-    int32  i2c_port_number                                    = 1; /** The desired I2C port. */
-    uint32 i2c_address                                        = 2; /** The 7-bit I2C address of the device on the bus. */
-    string i2c_device_name                                    = 3; /** The I2C device's name, MUST MATCH the name on the JSON file. */
-    repeated I2CDeviceSensorProperties i2c_device_properties  = 4[(nanopb).max_count = 15]; /** Properties for the I2C device's sensors. */
+  int32  i2c_port_number                                    = 1; /** The desired I2C port. */
+  uint32 i2c_address                                        = 2; /** The 7-bit I2C address of the device on the bus. */
+  string i2c_device_name                                    = 3; /** The I2C device's name, MUST MATCH the name on the JSON file. */
+  repeated I2CDeviceSensorProperties i2c_device_properties  = 4[(nanopb).max_count = 15]; /** Properties for the I2C device's sensors. */
 }
 
 /**
@@ -109,9 +109,9 @@ message I2CDeviceUpdateRequest {
 * sensor(s) is/are successfully updated.
 */
 message I2CDeviceUpdateResponse {
-    uint32 i2c_address          = 1; /** The 7-bit I2C address of the device which was updated. */
-    bool is_success             = 2; /** True if the update request succeeded, False otherwise. */
-    BusResponse bus_response    = 3; /** The I2C bus' status. **/
+  uint32 i2c_address          = 1; /** The 7-bit I2C address of the device which was updated. */
+  bool is_success             = 2; /** True if the update request succeeded, False otherwise. */
+  BusResponse bus_response    = 3; /** The I2C bus' status. **/
 }
 
 /**
@@ -119,8 +119,8 @@ message I2CDeviceUpdateResponse {
 * a deinitialization request for a specific i2c device.
 */
 message I2CDeviceDeinitRequest {
-    int32  i2c_port_number        = 1; /** The desired I2C port to de-initialize an I2C device on. */
-    uint32 i2c_address            = 2; /** The 7-bit I2C address of the device on the bus. */
+  int32  i2c_port_number        = 1; /** The desired I2C port to de-initialize an I2C device on. */
+  uint32 i2c_address            = 2; /** The 7-bit I2C address of the device on the bus. */
 }
 
 /**
@@ -128,8 +128,8 @@ message I2CDeviceDeinitRequest {
 * sensor(s) is/are successfully de-initialized.
 */
 message I2CDeviceDeinitResponse {
-    bool is_success     = 1; /** True if the deinitialization request succeeded, False otherwise. */
-    uint32 i2c_address  = 2; /** The 7-bit I2C address of the device which was initialized. */
+  bool is_success     = 1; /** True if the deinitialization request succeeded, False otherwise. */
+  uint32 i2c_address  = 2; /** The 7-bit I2C address of the device which was initialized. */
 }
 
 /** Adafruit Unified Sensor Library Messages. */

--- a/proto/wippersnapper/i2c/v1/i2c.proto
+++ b/proto/wippersnapper/i2c/v1/i2c.proto
@@ -70,7 +70,7 @@ message I2CBusScanResponse {
 */
 message I2CDeviceSensorProperties {
   SensorType sensor_type = 1;
-  float sensor_period    = 2;
+  uint32 sensor_period    = 2;
 }
 
 /**

--- a/proto/wippersnapper/i2c/v1/i2c.proto
+++ b/proto/wippersnapper/i2c/v1/i2c.proto
@@ -6,19 +6,20 @@ package wippersnapper.i2c.v1;
 import "nanopb/nanopb.proto";
 
 /**
-* BusResponse represents the I2C bus status.
+* BusResponse represents the state of the I2C bus, from a device.
 */
 enum BusResponse {
-  BUS_RESPONSE_UNSPECIFIED   = 0; /** Unspecified error occurred. **/
-  BUS_RESPONSE_SUCCESS       = 1; /** I2C bus successfully initialized. **/
-  BUS_RESPONSE_ERROR_HANG    = 2; /** I2C Bus hang, user should reset their board if this persists. **/
-  BUS_RESPONSE_ERROR_PULLUPS = 3; /** I2C bus failed to initialize - SDA or SCL needs a pull up. **/
-  BUS_RESPONSE_ERROR_WIRING  = 4; /** I2C bus failed to communicate - Please check your wiring. **/
+  BUS_RESPONSE_UNSPECIFIED         = 0; /** Unspecified error occurred. **/
+  BUS_RESPONSE_SUCCESS             = 1; /** I2C bus successfully initialized. **/
+  BUS_RESPONSE_ERROR_HANG          = 2; /** I2C Bus hang, user should reset their board if this persists. **/
+  BUS_RESPONSE_ERROR_PULLUPS       = 3; /** I2C bus failed to initialize - SDA or SCL needs a pull up. **/
+  BUS_RESPONSE_ERROR_WIRING        = 4; /** I2C bus failed to communicate - Please check your wiring. **/
+  BUS_RESPONSE_UNSUPPORTED_SENSOR  = 5; /** WipperSnapper firmware is outdated and does not include the sensor type - Please update your WipperSnapper firmware. **/
 }
 
 /**
 * I2CBusInitRequest represents a request to
-* initialize the I2C bus.
+* initialize the I2C bus from the broker.
 */
 message I2CBusInitRequest {
   int32  i2c_pin_scl     = 1; /** The desired I2C SCL pin. */
@@ -63,8 +64,9 @@ message I2CBusScanResponse {
 }
 
 /**
-* I2CDeviceSensorProperties contains the type and period
-* of an I2C device's sensor.
+* I2CDeviceSensorProperties contains
+* the properties of an I2C device's sensor such as
+* its type and period.
 */
 message I2CDeviceSensorProperties {
   SensorType sensor_type = 1;
@@ -72,20 +74,20 @@ message I2CDeviceSensorProperties {
 }
 
 /**
-* I2CDeviceInitRequest is a wrapper message containing
-* an i2c-device-specific initialization request.
+* I2CDeviceInitRequest is a wrapper message for
+* an I2C device initialization request.
 */
 message I2CDeviceInitRequest {
   int32  i2c_port_number                                    = 1; /** The desired I2C port to initialize an I2C device on. */
   I2CBusInitRequest i2c_bus_init_req                        = 2; /** An I2C bus initialization request. */
   uint32 i2c_device_address                                 = 3; /** The 7-bit I2C address of the device on the bus. */
-  string i2c_device_name                                    = 4; /** The I2C device's name, MUST MATCH the name on the JSON file. */
-  repeated I2CDeviceSensorProperties i2c_device_properties  = 5[(nanopb).max_count = 15]; /** Properties for the I2C device's sensors. */
+  string i2c_device_name                                    = 4; /** The I2C device's name, MUST MATCH the name on the JSON definition file on https://github.com/adafruit/Wippersnapper_Components. */
+  repeated I2CDeviceSensorProperties i2c_device_properties  = 5[(nanopb).max_count = 15]; /** Properties of each sensor on the I2C device. */
 }
 
 /**
-* I2CDeviceInitResponse represents if an i2c device
-* is successfully initialized by the client.
+* I2CDeviceInitResponse contains the response from a
+* device after processing a I2CDeviceInitRequest message.
 */
 message I2CDeviceInitResponse {
   bool is_success             = 1; /** True if i2c device initialized successfully, false otherwise. */
@@ -94,8 +96,8 @@ message I2CDeviceInitResponse {
 }
 
 /**
-* I2CDeviceUpdateRequest is a wrapper message containing
-* a update request for a specific i2c device.
+* I2CDeviceUpdateRequest is a wrapper message which
+* contains a message to update a specific device's properties.
 */
 message I2CDeviceUpdateRequest {
   int32  i2c_port_number                                    = 1; /** The desired I2C port. */
@@ -128,39 +130,9 @@ message I2CDeviceDeinitRequest {
 * sensor(s) is/are successfully de-initialized.
 */
 message I2CDeviceDeinitResponse {
-  bool is_success     = 1; /** True if the deinitialization request succeeded, False otherwise. */
-  uint32 i2c_address  = 2; /** The 7-bit I2C address of the device which was initialized. */
-}
-
-/**
-* PM25UpdateRequest represents the request to update or configure a PM25 AQ sensor.
-*/
-message PM25UpdateRequest {
-  bool enable_pm10_std   = 1; /** True to enable reading Standard PM1.0, False otherwise. */
-  float period_pm10_std  = 2;
-  bool enable_pm25_std   = 3; /** True to enable reading Standard PM2.5, False otherwise. */
-  float period_pm25_std  = 4;
-  bool enable_pm100_std  = 5; /** True to enable reading Standard PM10.0, False otherwise. */
-  float period_pm100_std = 6;
-  bool enable_pm10_env   = 7; /** True to enable reading Environmental PM1.0, False otherwise. */
-  float period_pm10_env  = 8;
-  bool enable_pm25_env   = 9; /** True to enable reading Environmental PM2.5, False otherwise. */
-  float period_pm25_env  = 10;
-  bool enable_pm100_env  = 11; /** True to enable reading Environmental PM10.0, False otherwise. */
-  float period_pm100_env = 12;
-}
-
-/**
-* BME280UpdateRequest represents the request to update or configure
-* a BME280 sensor.
-*/
-message BME280UpdateRequest {
-  bool enable_temperature   = 1; /** True to enable the BME280's temperature sensor, False to disable. */
-  float period_temperature  = 2; /** Specifies the time between temperature sensor measurements, in seconds. */
-  bool enable_humidity      = 3; /** True to enable the BME280's humidity sensor, False to disable. */
-  float period_humidity     = 4; /** Specifies the time between humidity sensor measurements, in seconds. */
-  bool enable_pressure      = 5; /** True to enable the BME280's pressure sensor, False to disable. */
-  float period_pressure     = 6; /** Specifies the time between pressure sensor measurements, in seconds. */
+  bool is_success           = 1; /** True if the deinitialization request succeeded, False otherwise. */
+  uint32 i2c_address        = 2; /** The 7-bit I2C address of the device which was initialized. */
+  BusResponse bus_response  = 3; /** The I2C bus' status. **/
 }
 
 /** Adafruit Unified Sensor Library Messages. */

--- a/proto/wippersnapper/i2c/v1/i2c.proto
+++ b/proto/wippersnapper/i2c/v1/i2c.proto
@@ -91,7 +91,7 @@ message I2CDeviceInitRequest {
 */
 message I2CDeviceInitResponse {
   bool is_success             = 1; /** True if i2c device initialized successfully, false otherwise. */
-  uint32 i2c_address          = 2; /** The 7-bit I2C address of the device on the bus. */
+  uint32 i2c_device_address   = 2; /** The 7-bit I2C address of the device on the bus. */
   BusResponse bus_response    = 3; /** The I2C bus' status. **/
 }
 
@@ -101,7 +101,7 @@ message I2CDeviceInitResponse {
 */
 message I2CDeviceUpdateRequest {
   int32  i2c_port_number                                    = 1; /** The desired I2C port. */
-  uint32 i2c_address                                        = 2; /** The 7-bit I2C address of the device on the bus. */
+  uint32 i2c_device_address                                 = 2; /** The 7-bit I2C address of the device on the bus. */
   string i2c_device_name                                    = 3[(nanopb).max_size = 15]; /** The I2C device's name, MUST MATCH the name on the JSON file. */
   repeated I2CDeviceSensorProperties i2c_device_properties  = 4[(nanopb).max_count = 15]; /** Properties for the I2C device's sensors. */
 }
@@ -111,7 +111,7 @@ message I2CDeviceUpdateRequest {
 * sensor(s) is/are successfully updated.
 */
 message I2CDeviceUpdateResponse {
-  uint32 i2c_address          = 1; /** The 7-bit I2C address of the device which was updated. */
+  uint32 i2c_device_address   = 1; /** The 7-bit I2C address of the device which was updated. */
   bool is_success             = 2; /** True if the update request succeeded, False otherwise. */
   BusResponse bus_response    = 3; /** The I2C bus' status. **/
 }
@@ -122,7 +122,7 @@ message I2CDeviceUpdateResponse {
 */
 message I2CDeviceDeinitRequest {
   int32  i2c_port_number        = 1; /** The desired I2C port to de-initialize an I2C device on. */
-  uint32 i2c_address            = 2; /** The 7-bit I2C address of the device on the bus. */
+  uint32 i2c_device_address     = 2; /** The 7-bit I2C address of the device on the bus. */
 }
 
 /**
@@ -131,7 +131,7 @@ message I2CDeviceDeinitRequest {
 */
 message I2CDeviceDeinitResponse {
   bool is_success           = 1; /** True if the deinitialization request succeeded, False otherwise. */
-  uint32 i2c_address        = 2; /** The 7-bit I2C address of the device which was initialized. */
+  uint32 i2c_device_address = 2; /** The 7-bit I2C address of the device which was initialized. */
   BusResponse bus_response  = 3; /** The I2C bus' status. **/
 }
 

--- a/proto/wippersnapper/i2c/v1/i2c.proto
+++ b/proto/wippersnapper/i2c/v1/i2c.proto
@@ -81,7 +81,7 @@ message I2CDeviceInitRequest {
   int32  i2c_port_number                                    = 1; /** The desired I2C port to initialize an I2C device on. */
   I2CBusInitRequest i2c_bus_init_req                        = 2; /** An I2C bus initialization request. */
   uint32 i2c_device_address                                 = 3; /** The 7-bit I2C address of the device on the bus. */
-  string i2c_device_name                                    = 4; /** The I2C device's name, MUST MATCH the name on the JSON definition file on https://github.com/adafruit/Wippersnapper_Components. */
+  string i2c_device_name                                    = 4[(nanopb).max_size = 15]; /** The I2C device's name, MUST MATCH the name on the JSON definition file on https://github.com/adafruit/Wippersnapper_Components. */
   repeated I2CDeviceSensorProperties i2c_device_properties  = 5[(nanopb).max_count = 15]; /** Properties of each sensor on the I2C device. */
 }
 
@@ -102,7 +102,7 @@ message I2CDeviceInitResponse {
 message I2CDeviceUpdateRequest {
   int32  i2c_port_number                                    = 1; /** The desired I2C port. */
   uint32 i2c_address                                        = 2; /** The 7-bit I2C address of the device on the bus. */
-  string i2c_device_name                                    = 3; /** The I2C device's name, MUST MATCH the name on the JSON file. */
+  string i2c_device_name                                    = 3[(nanopb).max_size = 15]; /** The I2C device's name, MUST MATCH the name on the JSON file. */
   repeated I2CDeviceSensorProperties i2c_device_properties  = 4[(nanopb).max_count = 15]; /** Properties for the I2C device's sensors. */
 }
 


### PR DESCRIPTION
**Breaking PR for both client and device**
Idea: Remove `SENSORNAMEUpdateRequest` sub-messages to be more generic and avoid adding to the size of this file every time we'd like to add a sensor. Users adding a sensor to the future component definition JSON repo should not need to also update i2c.proto. 

Changes:
* New Field, `i2c_device_name` should match the sensor's name from the JSON list.
* New message `I2CDeviceSensorProperties` holds the i2c device's sensor type and period. The period should be set to `0.0` if the sensor is not enabled in the modal. 
  * I2C devices may have multiple sensors, this field may be repeated.
* Removed sensor-specific `UpdateRequest` messages in favor of new scheme.