### PR TITLE
Simplify I2C responses

### DIFF
--- a/proto/wippersnapper/i2c/v1/i2c.proto
+++ b/proto/wippersnapper/i2c/v1/i2c.proto
@@ -140,7 +140,7 @@ message I2CDeviceDeinitRequest {
 * sensor(s) is/are successfully de-initialized.
 */
 message I2CDeviceDeinitResponse {
-  bool is_success           = 1; /** True if the deinitialization request succeeded, False otherwise. */
+  bool is_success           = 1 [deprecated = true, (nanopb).type = FT_IGNORE]; /** True if the deinitialization request succeeded, False otherwise. */
   uint32 i2c_device_address = 2; /** The 7-bit I2C address of the device which was initialized. */
   BusResponse bus_response  = 3; /** The I2C bus' status. **/
 }

--- a/proto/wippersnapper/i2c/v1/i2c.proto
+++ b/proto/wippersnapper/i2c/v1/i2c.proto
@@ -15,6 +15,8 @@ enum BusResponse {
   BUS_RESPONSE_ERROR_PULLUPS       = 3; /** I2C bus failed to initialize - SDA or SCL needs a pull up. **/
   BUS_RESPONSE_ERROR_WIRING        = 4; /** I2C bus failed to communicate - Please check your wiring. **/
   BUS_RESPONSE_UNSUPPORTED_SENSOR  = 5; /** WipperSnapper firmware is outdated and does not include the sensor type - Please update your WipperSnapper firmware. **/
+  BUS_RESPONSE_DEVICE_INIT_FAIL    = 6; /** I2C device failed to initialize. **/
+  BUS_RESPONSE_DEVICE_DEINIT_FAIL  = 7; /** I2C device failed to de-initialize. **/
 }
 
 /**
@@ -98,7 +100,7 @@ message I2CDeviceInitRequest {
 * device after processing a I2CDeviceInitRequest message.
 */
 message I2CDeviceInitResponse {
-  bool is_success             = 1; /** True if i2c device initialized successfully, false otherwise. */
+  bool is_success             = 1 [deprecated = true, (nanopb).type = FT_IGNORE]; /** !!DEPRECATED!! True if i2c device initialized successfully, false otherwise. */
   uint32 i2c_device_address   = 2; /** The 7-bit I2C address of the device on the bus. */
   BusResponse bus_response    = 3; /** The I2C bus' status. **/
 }
@@ -120,7 +122,7 @@ message I2CDeviceUpdateRequest {
 */
 message I2CDeviceUpdateResponse {
   uint32 i2c_device_address   = 1; /** The 7-bit I2C address of the device which was updated. */
-  bool is_success             = 2; /** True if the update request succeeded, False otherwise. */
+  bool is_success             = 2 [deprecated = true, (nanopb).type = FT_IGNORE]; /** !!DEPRECATED!! True if the update request succeeded, False otherwise. */
   BusResponse bus_response    = 3; /** The I2C bus' status. **/
 }
 

--- a/proto/wippersnapper/signal/v1/signal.proto
+++ b/proto/wippersnapper/signal/v1/signal.proto
@@ -17,7 +17,7 @@ import "wippersnapper/i2c/v1/i2c.proto";
 message I2CRequest {
   option (nanopb_msgopt).submsg_callback = true;
   oneof payload {
-    wippersnapper.i2c.v1.I2CBusInitRequest req_i2c_init                     = 1;
+    wippersnapper.i2c.v1.I2CBusInitRequest req_i2c_init                     = 1 [deprecated = true, (nanopb).type = FT_IGNORE];
     wippersnapper.i2c.v1.I2CBusScanRequest req_i2c_scan                     = 2;
     wippersnapper.i2c.v1.I2CBusSetFrequency req_i2c_set_freq                = 3;
     wippersnapper.i2c.v1.I2CDeviceInitRequest req_i2c_device_init           = 4;
@@ -33,7 +33,7 @@ message I2CRequest {
 message I2CResponse {
   option (nanopb_msgopt).submsg_callback = true;
   oneof payload {
-    wippersnapper.i2c.v1.I2CBusInitResponse resp_i2c_init                  = 1;
+    wippersnapper.i2c.v1.I2CBusInitResponse resp_i2c_init                  = 1 [deprecated = true, (nanopb).type = FT_IGNORE];
     wippersnapper.i2c.v1.I2CBusScanResponse resp_i2c_scan                  = 2;
     wippersnapper.i2c.v1.I2CDeviceInitResponse resp_i2c_device_init        = 3;
     wippersnapper.i2c.v1.I2CDeviceDeinitResponse resp_i2c_device_deinit    = 4;


### PR DESCRIPTION
* Deprecates `is_success` on:
  * `I2CDeviceInitResponse`
  * `I2CDeviceUpdateResponse`
  * `I2CDeviceDeinitResponse` 
* Adds two additional `BusResponse`s for error handling
* Deprecates `req_i2c_init` and `resp_i2c_init` as they are now packed within a `I2CBusScanRequest` or `I2CDeviceInitRequest`