### PR TITLE
Add Addressable Pixels API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -138,3 +138,9 @@ dmypy.json
 
 # Cython debug symbols
 cython_debug/
+
+.DS_STORE
+
+# Protoc run output folder
+# (i.e: protoc --plugin=nanopb/generator/protoc-gen-nanopb -Inanopb/generator/proto --proto_path=./proto ./proto/wippersnapper/*/*/*.proto --nanopb_out=./arduino_out --nanopb_opt=-I./proto --nanopb_opt=-t)
+arduino_out/

--- a/proto/wippersnapper/pixels/v1/pixels.proto
+++ b/proto/wippersnapper/pixels/v1/pixels.proto
@@ -7,23 +7,54 @@ syntax = "proto3";
 package wippersnapper.pixels.v1;
 import "nanopb/nanopb.proto";
 
-
+/**
+* Types of addressable pixels.
+*/
 enum PixelType {
   PIXEL_TYPE_UNSPECIFIED = 0; /** Unspecified pixel type. **/
   PIXEL_TYPE_NEOPIXEL    = 1; /** WS2812 (NeoPixel). **/
   PIXEL_TYPE_DOTSTAR     = 2; /** APA201 (DotStar). **/
 }
 
-// High-level, generalized pixel init?
-message PixelsInit {
-  uint32 num_pixels           = 1; /** The number of pixels in strand. */
-  PixelType pixel_type        = 2; /** The type of pin to send data out on. **/
-  NeoPixelInit neo_pixel_init = 3; /** Data used by the NeoPixel constructor. **/
-  DotStarInit dot_star_init   = 4; /** Data used by the DotStar constructor. **/
+/**
+* PixelsCreate creates a pixel object.
+*/
+message PixelsCreate {
+  uint32 pixel_num            = 1; /** The number of pixels in strand. */
+  uint32 pixel_brightness     = 2; /** Pixel's Brightness setting. 0=minimum (off), 255=brightest. */
+  PixelType pixel_type        = 3; /** The type of pixel used. **/
+  NeoPixelInit neo_pixel_init = 4; /** Data used by the NeoPixel constructor. **/
+  DotStarInit dot_star_init   = 5; /** Data used by the DotStar constructor. **/
 }
 
-/* NeoPixel */
+/**
+* PixelsDelete deletes and de-allocates a pixel object.
+*/
+message PixelsDelete {
+  PixelType pixel_type          = 3; /** The type of pixel to de-initialize. **/
+  NeoPixelInit neo_pixel_config = 4; /** Data used by the NeoPixel constructor. **/
+  DotStarInit dot_star_config   = 5; /** Data used by the DotStar constructor. **/
+}
 
+/**
+* PixelsFill fills all of a strip with one color.
+*/
+message PixelsFill {
+  uint32 color = 1; /** 32-bit color value. Most significant byte is white (for RGBW pixels) or ignored (for RGB pixels), next is red, then green, and least significant byte is blue. If all arguments are unspecified, this will be 0 (off). */
+}
+
+/**
+* DotStar constructor.
+*/
+message DotStarInit {
+  bool   use_hardware_spi = 1; /** Execute DotStar constructor for hardware SPI, must be connected to MOSI, SCK pins. */
+  uint32 pin_data         = 2; /** Arduino pin for data out, DotStar Software SPI. **/
+  uint32 pin_clock        = 3; /** Arduino pin for clock out, DotStar Software SPI. **/
+}
+
+/**
+* NeoPixel wiring types, used by NeoPixel constructor.
+*/
 enum NeoPixelType {
   NEO_PIXEL_TYPE_UNSPECIFIED = 0; /** Pixel type is unspecified. */
   NEO_PIXEL_TYPE_RGB         = 1; /** Pixels are wired for RGB bitstream. (v1 FLORA pixels). */
@@ -31,21 +62,20 @@ enum NeoPixelType {
   NEO_PIXEL_TYPE_RGBW        = 3; /** Pixel sare wired for RGBW bitstream (NeoPixel RGBW products). */
 }
 
+/**
+* NeoPixel bitstream speed, used by NeoPixel constructor.
+*/
 enum NeoPixelSpeed {
   NEO_PIXEL_SPEED_UNSPECIFIED = 0; /** Pixel speed is unspecified. */
   NEO_PIXEL_SPEED_KHZ800      = 1; /** 800KHz bitstream (most NeoPixel products w/WS2812 LEDs). */
   NEO_PIXEL_SPEED_KHZ400      = 2; /** 400KHz bitstream (classic "v1" FLORA pixels, WS2811 drivers). */
 }
 
+/**
+* NeoPixel constructor.
+*/
 message NeoPixelInit {
   uint32 neo_pixel_pin          = 1; /** The pin to send NeoPixel data out on. **/
   NeoPixelType  neo_pixel_type  = 2; /** NeoPixel wiring order. **/
   NeoPixelSpeed neo_pixel_speed = 3; /** NeoPixel speed. **/
-}
-
-/* DotStar */
-message DotStarInit {
-  bool   use_hardware_spi = 1; /** Execute DotStar constructor for hardware SPI, must be connected to MOSI, SCK pins. */
-  uint32 pin_data         = 2; /** Arduino pin for data out, DotStar Software SPI. **/
-  uint32 pin_clock        = 3; /** Arduino pin for clock out, DotStar Software SPI. **/
 }

--- a/proto/wippersnapper/pixels/v1/pixels.proto
+++ b/proto/wippersnapper/pixels/v1/pixels.proto
@@ -10,45 +10,46 @@ package wippersnapper.pixels.v1;
 * PixelsCreate creates a pixel object.
 */
 message PixelsCreate {
-  uint32 pixel_num            = 1; /** The number of pixels in strand. */
-  uint32 pixel_brightness     = 2; /** Pixel's Brightness setting. 0=minimum (off), 255=brightest. */
-  NeoPixelInit neo_pixel_init = 3; /** Data used by the NeoPixel constructor. **/
-  DotStarInit dot_star_init   = 4; /** Data used by the DotStar constructor. **/
+  uint32 pixel_num              = 1; /** The number of pixels in strand. */
+  uint32 pixel_brightness       = 2; /** Pixel's Brightness setting. 0=minimum (off), 255=brightest. */
+  NeoPixelConfig neo_pixel_init = 3; /** Data used by the NeoPixel constructor. **/
+  DotStarConfig dot_star_init   = 4; /** Data used by the DotStar constructor. **/
 }
 
 /**
 * PixelsUpdate updates the configuration of a pixel object.
 */
 message PixelsUpdate {
-  uint32 pixel_brightness       = 1; /** Pixel's Brightness setting. 0=minimum (off), 255=brightest. */
-  NeoPixelInit neo_pixel_config = 2; /** Data used by the NeoPixel object. **/
-  DotStarInit dot_star_config   = 3; /** Data used by the DotStar object. **/
+  uint32 pixel_brightness         = 1; /** Pixel's Brightness setting. 0=minimum (off), 255=brightest. */
+  NeoPixelConfig neo_pixel_config = 2; /** Data used by the NeoPixel object. **/
+  DotStarConfig dot_star_config   = 3; /** Data used by the DotStar object. **/
 }
 
 /**
 * PixelsDelete deletes and de-allocates a pixel object.
 */
 message PixelsDelete {
-  NeoPixelInit neo_pixel_config = 1; /** Data used by the NeoPixel object. **/
-  DotStarInit dot_star_config   = 2; /** Data used by the DotStar object. **/
+  NeoPixelConfig neo_pixel_config = 1; /** Data used by the NeoPixel object. **/
+  DotStarConfig dot_star_config   = 2; /** Data used by the DotStar object. **/
 }
 
 /**
 * PixelsFillAll fills all of a strip with one color.
 */
 message PixelsFillAll {
-  uint32 color = 1;                  /** 32-bit color value. Most significant byte is white (for RGBW pixels) or ignored (for RGB pixels), next is red, then green, and least significant byte is blue. If all arguments are unspecified, this will be 0 (off). */
-  NeoPixelInit neo_pixel_config = 2; /** Data used by the NeoPixel object. **/
-  DotStarInit dot_star_config = 3;   /** Data used by the DotStar object. **/
+  uint32 color                    = 1;                  /** 32-bit color value. Most significant byte is white (for RGBW pixels) or ignored (for RGB pixels), next is red, then green, and least significant byte is blue. If all arguments are unspecified, this will be 0 (off). */
+  NeoPixelConfig neo_pixel_config = 2; /** Data used by the NeoPixel object. **/
+  DotStarConfig dot_star_config   = 3;   /** Data used by the DotStar object. **/
 }
 
 /**
 * DotStar constructor.
 */
-message DotStarInit {
-  bool   use_hardware_spi = 1; /** Execute DotStar constructor for hardware SPI, must be connected to MOSI, SCK pins. */
-  uint32 pin_data         = 2; /** Arduino pin for data out, DotStar Software SPI. **/
-  uint32 pin_clock        = 3; /** Arduino pin for clock out, DotStar Software SPI. **/
+message DotStarConfig {
+  uint32 pixel_num        = 1; /** REQUIRED, the number of pixels in the strand, used for addressing a DotStar strand. */
+  bool   use_hardware_spi = 2; /** Hardware SPI Only, execute DotStar constructor for hardware SPI, must be connected to MOSI, SCK pins. */
+  uint32 pin_data         = 3; /** Software SPI Only, Arduino pin for data out. **/
+  uint32 pin_clock        = 4; /** Software SPI Only, Arduino pin for clock out. **/
 }
 
 /**
@@ -73,7 +74,7 @@ enum NeoPixelSpeed {
 /**
 * NeoPixel constructor.
 */
-message NeoPixelInit {
+message NeoPixelConfig {
   uint32 neo_pixel_pin          = 1; /** The pin to send NeoPixel data out on. **/
   NeoPixelType  neo_pixel_type  = 2; /** NeoPixel wiring order. **/
   NeoPixelSpeed neo_pixel_speed = 3; /** NeoPixel speed. **/

--- a/proto/wippersnapper/pixels/v1/pixels.proto
+++ b/proto/wippersnapper/pixels/v1/pixels.proto
@@ -1,0 +1,51 @@
+// SPDX-FileCopyrightText: 2022 Brent Rubell for Adafruit Industries
+// SPDX-License-Identifier: MIT
+// Addressable Pixel API for WipperSnapper
+// based off Adafruit BLE's Addressable Pixel Service (https://github.com/adafruit/bluetooth-low-energy#addressable-pixel-service---0x0900)
+syntax = "proto3";
+
+package wippersnapper.pixels.v1;
+import "nanopb/nanopb.proto";
+
+
+enum PixelType {
+  PIXEL_TYPE_UNSPECIFIED = 0; /** Unspecified pixel type. **/
+  PIXEL_TYPE_NEOPIXEL    = 1; /** WS2812 (NeoPixel). **/
+  PIXEL_TYPE_DOTSTAR     = 2; /** APA201 (DotStar). **/
+}
+
+// High-level, generalized pixel init?
+message PixelsInit {
+  uint32 num_pixels           = 1; /** The number of pixels in strand. */
+  PixelType pixel_type        = 2; /** The type of pin to send data out on. **/
+  NeoPixelInit neo_pixel_init = 3; /** Data used by the NeoPixel constructor. **/
+  DotStarInit dot_star_init   = 4; /** Data used by the DotStar constructor. **/
+}
+
+/* NeoPixel */
+
+enum NeoPixelType {
+  NEO_PIXEL_TYPE_UNSPECIFIED = 0; /** Pixel type is unspecified. */
+  NEO_PIXEL_TYPE_RGB         = 1; /** Pixels are wired for RGB bitstream. (v1 FLORA pixels). */
+  NEO_PIXEL_TYPE_GRB         = 2; /** Pixels are wired for GRB bitstream (most NeoPixel products). */
+  NEO_PIXEL_TYPE_RGBW        = 3; /** Pixel sare wired for RGBW bitstream (NeoPixel RGBW products). */
+}
+
+enum NeoPixelSpeed {
+  NEO_PIXEL_SPEED_UNSPECIFIED = 0; /** Pixel speed is unspecified. */
+  NEO_PIXEL_SPEED_KHZ800      = 1; /** 800KHz bitstream (most NeoPixel products w/WS2812 LEDs). */
+  NEO_PIXEL_SPEED_KHZ400      = 2; /** 400KHz bitstream (classic "v1" FLORA pixels, WS2811 drivers). */
+}
+
+message NeoPixelInit {
+  uint32 neo_pixel_pin          = 1; /** The pin to send NeoPixel data out on. **/
+  NeoPixelType  neo_pixel_type  = 2; /** NeoPixel wiring order. **/
+  NeoPixelSpeed neo_pixel_speed = 3; /** NeoPixel speed. **/
+}
+
+/* DotStar */
+message DotStarInit {
+  bool   use_hardware_spi = 1; /** Execute DotStar constructor for hardware SPI, must be connected to MOSI, SCK pins. */
+  uint32 pin_data         = 2; /** Arduino pin for data out, DotStar Software SPI. **/
+  uint32 pin_clock        = 3; /** Arduino pin for clock out, DotStar Software SPI. **/
+}

--- a/proto/wippersnapper/pixels/v1/pixels.proto
+++ b/proto/wippersnapper/pixels/v1/pixels.proto
@@ -46,9 +46,9 @@ message PixelsDelete {
 }
 
 /**
-* PixelsFill fills all of a strip with one color.
+* PixelsFillAll fills all of a strip with one color.
 */
-message PixelsFill {
+message PixelsFillAll {
   uint32 color = 1; /** 32-bit color value. Most significant byte is white (for RGBW pixels) or ignored (for RGB pixels), next is red, then green, and least significant byte is blue. If all arguments are unspecified, this will be 0 (off). */
 }
 

--- a/proto/wippersnapper/pixels/v1/pixels.proto
+++ b/proto/wippersnapper/pixels/v1/pixels.proto
@@ -7,49 +7,39 @@ syntax = "proto3";
 package wippersnapper.pixels.v1;
 
 /**
-* Types of addressable pixels.
-*/
-enum PixelType {
-  PIXEL_TYPE_UNSPECIFIED = 0; /** Unspecified pixel type. **/
-  PIXEL_TYPE_NEOPIXEL    = 1; /** WS2812 (NeoPixel). **/
-  PIXEL_TYPE_DOTSTAR     = 2; /** APA201 (DotStar). **/
-}
-
-/**
 * PixelsCreate creates a pixel object.
 */
 message PixelsCreate {
   uint32 pixel_num            = 1; /** The number of pixels in strand. */
   uint32 pixel_brightness     = 2; /** Pixel's Brightness setting. 0=minimum (off), 255=brightest. */
-  PixelType pixel_type        = 3; /** The type of pixel used. **/
-  NeoPixelInit neo_pixel_init = 4; /** Data used by the NeoPixel constructor. **/
-  DotStarInit dot_star_init   = 5; /** Data used by the DotStar constructor. **/
+  NeoPixelInit neo_pixel_init = 3; /** Data used by the NeoPixel constructor. **/
+  DotStarInit dot_star_init   = 4; /** Data used by the DotStar constructor. **/
 }
 
 /**
 * PixelsUpdate updates the configuration of a pixel object.
 */
 message PixelsUpdate {
-  PixelType pixel_type          = 1; /** The type of pixel to de-initialize. **/
-  uint32 pixel_brightness       = 2; /** Pixel's Brightness setting. 0=minimum (off), 255=brightest. */
-  NeoPixelInit neo_pixel_config = 3; /** Data used by the NeoPixel constructor. **/
-  DotStarInit dot_star_config   = 4; /** Data used by the DotStar constructor. **/
+  uint32 pixel_brightness       = 1; /** Pixel's Brightness setting. 0=minimum (off), 255=brightest. */
+  NeoPixelInit neo_pixel_config = 2; /** Data used by the NeoPixel object. **/
+  DotStarInit dot_star_config   = 3; /** Data used by the DotStar object. **/
 }
 
 /**
 * PixelsDelete deletes and de-allocates a pixel object.
 */
 message PixelsDelete {
-  PixelType pixel_type          = 3; /** The type of pixel to de-initialize. **/
-  NeoPixelInit neo_pixel_config = 4; /** Data used by the NeoPixel constructor. **/
-  DotStarInit dot_star_config   = 5; /** Data used by the DotStar constructor. **/
+  NeoPixelInit neo_pixel_config = 1; /** Data used by the NeoPixel object. **/
+  DotStarInit dot_star_config   = 2; /** Data used by the DotStar object. **/
 }
 
 /**
 * PixelsFillAll fills all of a strip with one color.
 */
 message PixelsFillAll {
-  uint32 color = 1; /** 32-bit color value. Most significant byte is white (for RGBW pixels) or ignored (for RGB pixels), next is red, then green, and least significant byte is blue. If all arguments are unspecified, this will be 0 (off). */
+  uint32 color = 1;                  /** 32-bit color value. Most significant byte is white (for RGBW pixels) or ignored (for RGB pixels), next is red, then green, and least significant byte is blue. If all arguments are unspecified, this will be 0 (off). */
+  NeoPixelInit neo_pixel_config = 2; /** Data used by the NeoPixel object. **/
+  DotStarInit dot_star_config = 3;   /** Data used by the DotStar object. **/
 }
 
 /**

--- a/proto/wippersnapper/pixels/v1/pixels.proto
+++ b/proto/wippersnapper/pixels/v1/pixels.proto
@@ -5,7 +5,6 @@
 syntax = "proto3";
 
 package wippersnapper.pixels.v1;
-import "nanopb/nanopb.proto";
 
 /**
 * Types of addressable pixels.
@@ -25,6 +24,16 @@ message PixelsCreate {
   PixelType pixel_type        = 3; /** The type of pixel used. **/
   NeoPixelInit neo_pixel_init = 4; /** Data used by the NeoPixel constructor. **/
   DotStarInit dot_star_init   = 5; /** Data used by the DotStar constructor. **/
+}
+
+/**
+* PixelsUpdate updates the configuration of a pixel object.
+*/
+message PixelsUpdate {
+  PixelType pixel_type          = 1; /** The type of pixel to de-initialize. **/
+  uint32 pixel_brightness       = 2; /** Pixel's Brightness setting. 0=minimum (off), 255=brightest. */
+  NeoPixelInit neo_pixel_config = 3; /** Data used by the NeoPixel constructor. **/
+  DotStarInit dot_star_config   = 4; /** Data used by the DotStar constructor. **/
 }
 
 /**

--- a/proto/wippersnapper/signal/v1/signal.proto
+++ b/proto/wippersnapper/signal/v1/signal.proto
@@ -50,8 +50,9 @@ message PixelRequest {
   option (nanopb_msgopt).submsg_callback = true;
   oneof payload {
     wippersnapper.pixels.v1.PixelsCreate req_pixels_create = 1;
-    wippersnapper.pixels.v1.PixelsDelete req_pixels_delete = 2;
-    wippersnapper.pixels.v1.PixelsFill req_pixels_fill     = 3;
+    wippersnapper.pixels.v1.PixelsUpdate req_pixels_update = 2;
+    wippersnapper.pixels.v1.PixelsDelete req_pixels_delete = 3;
+    wippersnapper.pixels.v1.PixelsFill req_pixels_fill     = 4;
   }
 }
 

--- a/proto/wippersnapper/signal/v1/signal.proto
+++ b/proto/wippersnapper/signal/v1/signal.proto
@@ -49,10 +49,10 @@ message I2CResponse {
 message PixelRequest {
   option (nanopb_msgopt).submsg_callback = true;
   oneof payload {
-    wippersnapper.pixels.v1.PixelsCreate req_pixels_create = 1;
-    wippersnapper.pixels.v1.PixelsUpdate req_pixels_update = 2;
-    wippersnapper.pixels.v1.PixelsDelete req_pixels_delete = 3;
-    wippersnapper.pixels.v1.PixelsFill req_pixels_fill     = 4;
+    wippersnapper.pixels.v1.PixelsCreate req_pixels_create    = 1;
+    wippersnapper.pixels.v1.PixelsUpdate req_pixels_update    = 2;
+    wippersnapper.pixels.v1.PixelsDelete req_pixels_delete    = 3;
+    wippersnapper.pixels.v1.PixelsFillAll req_pixels_fill_all = 4;
   }
 }
 

--- a/proto/wippersnapper/signal/v1/signal.proto
+++ b/proto/wippersnapper/signal/v1/signal.proto
@@ -10,6 +10,7 @@ import "nanopb/nanopb.proto";
 // WipperSnapper
 import "wippersnapper/pin/v1/pin.proto";
 import "wippersnapper/i2c/v1/i2c.proto";
+import "wippersnapper/pixels/v1/pixels.proto";
 
 /**
 * I2CRequest represents the broker's request for a specific i2c command to a device.
@@ -39,6 +40,18 @@ message I2CResponse {
     wippersnapper.i2c.v1.I2CDeviceDeinitResponse resp_i2c_device_deinit    = 4;
     wippersnapper.i2c.v1.I2CDeviceUpdateResponse resp_i2c_device_update    = 5;
     wippersnapper.i2c.v1.I2CDeviceEvent resp_i2c_device_event              = 6;
+  }
+}
+
+/**
+* PixelRequest represents messages sent to the device from a pixel component.
+*/
+message PixelRequest {
+  option (nanopb_msgopt).submsg_callback = true;
+  oneof payload {
+    wippersnapper.pixels.v1.PixelsCreate req_pixels_create = 1;
+    wippersnapper.pixels.v1.PixelsDelete req_pixels_delete = 2;
+    wippersnapper.pixels.v1.PixelsFill req_pixels_fill     = 3;
   }
 }
 


### PR DESCRIPTION
Unified message API for controlling addressable pixels such as NeoPixels and DotStars.

* `PixelsCreate` - creates a pixel object.
* `PixelsUpdate` - updates the configuration of a pixel object.
* `PixelsDelete` - deletes and de-allocates a pixel object.
* `PixelsFill` - fills all of a strip with one color.


Resolves https://github.com/adafruit/Wippersnapper_Protobuf/issues/90