### PR TITLE
Add Servo Support

### DIFF
--- a/proto/wippersnapper/servo/v1/servo.proto
+++ b/proto/wippersnapper/servo/v1/servo.proto
@@ -1,0 +1,28 @@
+// SPDX-FileCopyrightText: 2022 Brent Rubell for Adafruit Industries
+// SPDX-License-Identifier: MIT
+syntax = "proto3";
+
+package wippersnapper.servo.v1;
+import "nanopb/nanopb.proto";
+
+/**
+* ServoInitReq represents a message to configure/use a pin as a servo object.
+*
+* NOTE: Frequency is fixed at 50Hz in this implementation and some MCUs have a
+* default freqency. This will need to be handled by the client.
+*/
+message ServoInitReq {
+  string pin_name = 1 [(nanopb).max_size = 5]; /** The name of pin to use as a servo pin. */
+}
+
+
+/**
+* ServoWriteReq represents a message to write the servo's position.
+*
+* NOTE: Position is sent from Adafruit IO as a pulse width in uS between 500uS
+* and 2500uS. The client application must convert pulse width to duty cycle w/fixed
+* freq of 50Hz prior to writing to the servo pin.
+*/
+message ServoWriteReq {
+  int32  pulse_width = 1; /** The pulse width to write to the servo, in uS **/
+}

--- a/proto/wippersnapper/signal/v1/signal.proto
+++ b/proto/wippersnapper/signal/v1/signal.proto
@@ -10,6 +10,7 @@ import "nanopb/nanopb.proto";
 // WipperSnapper
 import "wippersnapper/pin/v1/pin.proto";
 import "wippersnapper/i2c/v1/i2c.proto";
+import "wippersnapper/servo/v1/servo.proto";
 
 /**
 * I2CRequest represents the broker's request for a specific i2c command to a device.
@@ -39,6 +40,14 @@ message I2CResponse {
     wippersnapper.i2c.v1.I2CDeviceDeinitResponse resp_i2c_device_deinit    = 4;
     wippersnapper.i2c.v1.I2CDeviceUpdateResponse resp_i2c_device_update    = 5;
     wippersnapper.i2c.v1.I2CDeviceEvent resp_i2c_device_event              = 6;
+  }
+}
+
+message ServoRequest {
+  option (nanopb_msgopt).submsg_callback = true;
+  oneof payload {
+    wippersnapper.servo.v1.ServoInitReq  servo_init = 1;
+    wippersnapper.servo.v1.ServoWriteReq servo_write = 2;
   }
 }
 


### PR DESCRIPTION
Draft of Servo API, subject to change during implementation in code.

Messages (WIP)
* ServoInitReq - Message to configure/use a pin as a servo object.
  * Frequency is fixed at 50Hz for this implementation (@ladyada  - Would we ever want a variable freq. in this API). If we're going with a 50Hz fixed frequency, the freq. would not be sent by IO, it would be implemented client-side, in WipperSnapper.
* ServoWriteReq - Message to write a value to a servo object.
  * pulse_width is sent by the device's Adafruit IO dashboard using a slider
  * 500uS < pulse_width < 2500uS

Resolves https://github.com/adafruit/Wippersnapper_Protobuf/issues/91