### PR TITLE
Add missing SI units to SensorTypes

### DIFF
--- a/proto/wippersnapper/i2c/v1/i2c.proto
+++ b/proto/wippersnapper/i2c/v1/i2c.proto
@@ -151,35 +151,35 @@ message I2CDeviceDeinitResponse {
 * SensorType allows us determine what types of units the sensor uses, etc.
 */
 enum SensorType {
-  SENSOR_TYPE_UNSPECIFIED         = 0;  /** Sensor value type which is not defined by this list, error. */
-  SENSOR_TYPE_ACCELEROMETER       = 1;  /** Acceleration, in meter per second per second. */
-  SENSOR_TYPE_MAGNETIC_FIELD      = 2;  /** Magnetic field strength, in micro-Tesla. */
-  SENSOR_TYPE_ORIENTATION         = 3;  /** Orientation angle, in degrees. */
-  SENSOR_TYPE_GYROSCOPE           = 4;  /** Angular rate, in radians per second. */
-  SENSOR_TYPE_LIGHT               = 5;  /** Light-level, non-unit-specific (For a unit-specific measurement, see: Lux). */
-  SENSOR_TYPE_PRESSURE            = 6;  /** Pressure, in hectopascal. */
-  SENSOR_TYPE_PROXIMITY           = 8;  /** Distance from an object to a sensor, non-unit-specific. */
-  SENSOR_TYPE_GRAVITY             = 9;  /** Metres per second squared. */
-  SENSOR_TYPE_LINEAR_ACCELERATION = 10; /** Acceleration not including gravity, in meter per second squared. */
-  SENSOR_TYPE_ROTATION_VECTOR     = 11; /** An angle in radians. */
-  SENSOR_TYPE_RELATIVE_HUMIDITY   = 12; /** in percent (%). */
-  SENSOR_TYPE_AMBIENT_TEMPERATURE = 13; /** Temperature of the air around a sensor, in degrees Celsius. */
-  SENSOR_TYPE_OBJECT_TEMPERATURE  = 14; /** Temperature of the object a sensor is touching/pointed at, in degrees Celsius. */
-  SENSOR_TYPE_VOLTAGE             = 15; /** Volts (V). */
-  SENSOR_TYPE_CURRENT             = 16; /** Milliamps (mA). */
-  SENSOR_TYPE_COLOR               = 17; /** Values are in 0..1.0 RGB channel luminosity and 32-bit RGBA format. */
-  SENSOR_TYPE_RAW                 = 18; /** Sensor reads a value which is not defined by this list. */
-  SENSOR_TYPE_PM10_STD            = 19; /** Standard Particulate Matter 1.0, in ppm */
-  SENSOR_TYPE_PM25_STD            = 20; /** Standard Particulate Matter 2.5, in ppm. */
-  SENSOR_TYPE_PM100_STD           = 21; /** Standard Particulate Matter 100, in ppm. */
-  SENSOR_TYPE_PM10_ENV            = 22; /** Environmental Particulate Matter 1.0, in ppm. */
-  SENSOR_TYPE_PM25_ENV            = 23; /** Environmental Particulate Matter 2.5, in ppm. */
-  SENSOR_TYPE_PM100_ENV           = 24; /** Environmental Particulate Matter 100, in ppm. */
-  SENSOR_TYPE_CO2                 = 25; /** Measured CO2, in ppm. */
-  SENSOR_TYPE_GAS_RESISTANCE      = 26; /** Proportional to the amount of VOC particles in the air, in Ohms */
-  SENSOR_TYPE_ALTITUDE            = 27; /** Altitude, in meters. */
-  SENSOR_TYPE_LUX                 = 28; /** Light level, in lux. */
-  SENSOR_TYPE_ECO2                = 29; /** equivalent/estimated CO2 in ppm (estimated from some other measurement). */
+  SENSOR_TYPE_UNSPECIFIED         = 0;  /** Sensor value type which is not defined by this list, "Raw Value: {value}". */
+  SENSOR_TYPE_ACCELEROMETER       = 1;  /** Acceleration, in meter per second per second, "{value}m/s/s". */
+  SENSOR_TYPE_MAGNETIC_FIELD      = 2;  /** Magnetic field strength, in micro-Tesla, "{value}µT". */
+  SENSOR_TYPE_ORIENTATION         = 3;  /** Orientation angle, in degrees, "{value}°". */
+  SENSOR_TYPE_GYROSCOPE           = 4;  /** Angular rate, in radians per second, "{value}rad/s". */
+  SENSOR_TYPE_LIGHT               = 5;  /** Light-level, non-unit-specific (For a unit-specific measurement, see: Lux), , "Raw Value: {value}". */
+  SENSOR_TYPE_PRESSURE            = 6;  /** Pressure, in hectopascal, , "{value}hPa". */
+  SENSOR_TYPE_PROXIMITY           = 8;  /** Distance from an object to a sensor, non-unit-specific, "Raw Value: {value}". */
+  SENSOR_TYPE_GRAVITY             = 9;  /** Metres per second squared, "{value}m/s^2". */
+  SENSOR_TYPE_LINEAR_ACCELERATION = 10; /** Acceleration not including gravity, in meter per second squared, "{value}m/s^2". */
+  SENSOR_TYPE_ROTATION_VECTOR     = 11; /** An angle in radians, "{value} rad".*/
+  SENSOR_TYPE_RELATIVE_HUMIDITY   = 12; /** in percent (%), "{value}%". */
+  SENSOR_TYPE_AMBIENT_TEMPERATURE = 13; /** Temperature of the air around a sensor, in degrees Celsius, "{value}°C". */
+  SENSOR_TYPE_OBJECT_TEMPERATURE  = 14; /** Temperature of the object a sensor is touching/pointed at, in degrees Celsius, "{value}°C".*/
+  SENSOR_TYPE_VOLTAGE             = 15; /** Volts, "{value}V". */
+  SENSOR_TYPE_CURRENT             = 16; /** Milliamps, "{value}mA". */
+  SENSOR_TYPE_COLOR               = 17; /** Values are in 0..1.0 RGB channel luminosity and 32-bit RGBA format. "Color: {value}".*/
+  SENSOR_TYPE_RAW                 = 18; /** Sensor reads a value which is not defined by this list, "Raw Value: {value}".*/
+  SENSOR_TYPE_PM10_STD            = 19; /** Standard Particulate Matter 1.0, in ppm, "{value}ppm". */
+  SENSOR_TYPE_PM25_STD            = 20; /** Standard Particulate Matter 2.5, in ppm, "{value}ppm". */
+  SENSOR_TYPE_PM100_STD           = 21; /** Standard Particulate Matter 100, in ppm, "{value}ppm". */
+  SENSOR_TYPE_PM10_ENV            = 22; /** Environmental Particulate Matter 1.0, in ppm, "{value}ppm". */
+  SENSOR_TYPE_PM25_ENV            = 23; /** Environmental Particulate Matter 2.5, in ppm, "{value}ppm". */
+  SENSOR_TYPE_PM100_ENV           = 24; /** Environmental Particulate Matter 100, in ppm, "{value}ppm".*/
+  SENSOR_TYPE_CO2                 = 25; /** Measured CO2, in ppm, "{value}ppm". */
+  SENSOR_TYPE_GAS_RESISTANCE      = 26; /** Proportional to the amount of VOC particles in the air, in Ohms, "{value}Ω". */
+  SENSOR_TYPE_ALTITUDE            = 27; /** Altitude, in meters,"{value}m". */
+  SENSOR_TYPE_LUX                 = 28; /** Light level, in lux, "Lux: {value}". */
+  SENSOR_TYPE_ECO2                = 29; /** equivalent/estimated CO2 in ppm (estimated from some other measurement), "{value}ppm". */
 }
 
 /**

--- a/proto/wippersnapper/i2c/v1/i2c.proto
+++ b/proto/wippersnapper/i2c/v1/i2c.proto
@@ -151,33 +151,35 @@ message I2CDeviceDeinitResponse {
 * SensorType allows us determine what types of units the sensor uses, etc.
 */
 enum SensorType {
-  SENSOR_TYPE_UNSPECIFIED         = 0;
-  SENSOR_TYPE_ACCELEROMETER       = 1; /** Gravity + linear acceleration */
-  SENSOR_TYPE_MAGNETIC_FIELD      = 2;
-  SENSOR_TYPE_ORIENTATION         = 3;
-  SENSOR_TYPE_GYROSCOPE           = 4;
-  SENSOR_TYPE_LIGHT               = 5;
-  SENSOR_TYPE_PRESSURE            = 6;
-  SENSOR_TYPE_PROXIMITY           = 8;
-  SENSOR_TYPE_GRAVITY             = 9;
-  SENSOR_TYPE_LINEAR_ACCELERATION = 10; /** Acceleration not including gravity */
-  SENSOR_TYPE_ROTATION_VECTOR     = 11;
-  SENSOR_TYPE_RELATIVE_HUMIDITY   = 12;
-  SENSOR_TYPE_AMBIENT_TEMPERATURE = 13;
-  SENSOR_TYPE_OBJECT_TEMPERATURE  = 14;
-  SENSOR_TYPE_VOLTAGE             = 15;
-  SENSOR_TYPE_CURRENT             = 16;
-  SENSOR_TYPE_COLOR               = 17;
-  SENSOR_TYPE_RAW                 = 18;
-  SENSOR_TYPE_PM10_STD            = 19; /** Standard Particulate Matter 1.0 */
-  SENSOR_TYPE_PM25_STD            = 20; /** Standard Particulate Matter 2.5 */
-  SENSOR_TYPE_PM100_STD           = 21; /** Standard Particulate Matter 100 */
-  SENSOR_TYPE_PM10_ENV            = 22; /** Environmental Particulate Matter 1.0 */
-  SENSOR_TYPE_PM25_ENV            = 23; /** Environmental Particulate Matter 2.5 */
-  SENSOR_TYPE_PM100_ENV           = 24; /** Environmental Particulate Matter 100 */
-  SENSOR_TYPE_CO2                 = 25; /** CO2 */
-  SENSOR_TYPE_GAS_RESISTANCE      = 26; /** The resistance (in Ohms) of the gas sensor.  This is proportional to the amount of VOC particles in the air. */
-  SENSOR_TYPE_ALTITUDE            = 27; /** The altitude in meters. */
+  SENSOR_TYPE_UNSPECIFIED         = 0;  /** Sensor value type which is not defined by this list, error. */
+  SENSOR_TYPE_ACCELEROMETER       = 1;  /** Acceleration, in meter per second per second. */
+  SENSOR_TYPE_MAGNETIC_FIELD      = 2;  /** Magnetic field strength, in micro-Tesla. */
+  SENSOR_TYPE_ORIENTATION         = 3;  /** Orientation angle, in degrees. */
+  SENSOR_TYPE_GYROSCOPE           = 4;  /** Angular rate, in radians per second. */
+  SENSOR_TYPE_LIGHT               = 5;  /** Light-level, non-unit-specific (For a unit-specific measurement, see: Lux). */
+  SENSOR_TYPE_PRESSURE            = 6;  /** Pressure, in hectopascal. */
+  SENSOR_TYPE_PROXIMITY           = 8;  /** Distance from an object to a sensor, non-unit-specific. */
+  SENSOR_TYPE_GRAVITY             = 9;  /** Metres per second squared. */
+  SENSOR_TYPE_LINEAR_ACCELERATION = 10; /** Acceleration not including gravity, in meter per second squared. */
+  SENSOR_TYPE_ROTATION_VECTOR     = 11; /** An angle in radians. */
+  SENSOR_TYPE_RELATIVE_HUMIDITY   = 12; /** in percent (%). */
+  SENSOR_TYPE_AMBIENT_TEMPERATURE = 13; /** Temperature of the air around a sensor, in degrees Celsius. */
+  SENSOR_TYPE_OBJECT_TEMPERATURE  = 14; /** Temperature of the object a sensor is touching/pointed at, in degrees Celsius. */
+  SENSOR_TYPE_VOLTAGE             = 15; /** Volts (V). */
+  SENSOR_TYPE_CURRENT             = 16; /** Milliamps (mA). */
+  SENSOR_TYPE_COLOR               = 17; /** Values are in 0..1.0 RGB channel luminosity and 32-bit RGBA format. */
+  SENSOR_TYPE_RAW                 = 18; /** Sensor reads a value which is not defined by this list. */
+  SENSOR_TYPE_PM10_STD            = 19; /** Standard Particulate Matter 1.0, in ppm */
+  SENSOR_TYPE_PM25_STD            = 20; /** Standard Particulate Matter 2.5, in ppm. */
+  SENSOR_TYPE_PM100_STD           = 21; /** Standard Particulate Matter 100, in ppm. */
+  SENSOR_TYPE_PM10_ENV            = 22; /** Environmental Particulate Matter 1.0, in ppm. */
+  SENSOR_TYPE_PM25_ENV            = 23; /** Environmental Particulate Matter 2.5, in ppm. */
+  SENSOR_TYPE_PM100_ENV           = 24; /** Environmental Particulate Matter 100, in ppm. */
+  SENSOR_TYPE_CO2                 = 25; /** Measured CO2, in ppm. */
+  SENSOR_TYPE_GAS_RESISTANCE      = 26; /** Proportional to the amount of VOC particles in the air, in Ohms */
+  SENSOR_TYPE_ALTITUDE            = 27; /** Altitude, in meters. */
+  SENSOR_TYPE_LUX                 = 28; /** Light level, in lux. */
+  SENSOR_TYPE_ECO2                = 29; /** equivalent/estimated CO2 in ppm (estimated from some other measurement). */
 }
 
 /**


### PR DESCRIPTION
Adds comments to each `SensorType` with its corresponding SI unit.

Resolves https://github.com/adafruit/Wippersnapper_Protobuf/issues/96