### PR TITLE
Add PWM API

### DIFF
--- a/proto/wippersnapper/pin/v1/pin.proto
+++ b/proto/wippersnapper/pin/v1/pin.proto
@@ -105,10 +105,11 @@ message PinEvents {
   repeated PinEvent list = 1;
 }
 
-/* PWM Pin API */
+/* DEPRECATED - PWM Pin API */
 
 // Configures a PWM output pin
 message ConfigurePWMPinRequest {
+  option deprecated = true;
   // Pin to write to
   string pin_name         = 1 [(nanopb).max_size = 5];
 
@@ -125,16 +126,19 @@ message ConfigurePWMPinRequest {
 }
 
 message ConfigurePWMPinRequests {
+  option deprecated = true;
   repeated ConfigurePWMPinRequest list = 1;
 }
 
 // Write duty cycle to a pin PWM output pin
 message PWMPinEvent {
+  option deprecated = true;
   // Duty cycle between always off (0)
   // and always on (255)
   int32 duty_cycle        = 2;
 }
 
 message PWMPinEvents {
+  option deprecated = true;
   repeated PWMPinEvent list = 1;
 }

--- a/proto/wippersnapper/pin/v1/pin.proto
+++ b/proto/wippersnapper/pin/v1/pin.proto
@@ -102,7 +102,7 @@ message ConfigureReferenceVoltage {
 */
 message PinEvents {
   option deprecated = true; 
-  repeated PinEvent list = 1;
+  repeated PinEvent list = 1 [deprecated = true, (nanopb).type = FT_IGNORE];
 }
 
 /* DEPRECATED - PWM Pin API */
@@ -111,23 +111,23 @@ message PinEvents {
 message ConfigurePWMPinRequest {
   option deprecated = true;
   // Pin to write to
-  string pin_name         = 1 [(nanopb).max_size = 5];
+  string pin_name         = 1 [(nanopb).max_size = 5, deprecated = true, (nanopb).type = FT_IGNORE];
 
   // Duty cycle between always off (0)
   // and always on (255)
-  int32 duty_cycle        = 2;
+  int32 duty_cycle        = 2 [deprecated = true, (nanopb).type = FT_IGNORE];
 
   // Target frequency, in Hz
-  int32 frequency         = 3;
+  int32 frequency         = 3 [deprecated = true, (nanopb).type = FT_IGNORE];
 
   // If the frequency changes over time
   // NOTE: CIRCUITPYTHON-API ONLY
-  bool variable_frequency = 4;
+  bool variable_frequency = 4 [deprecated = true, (nanopb).type = FT_IGNORE];
 }
 
 message ConfigurePWMPinRequests {
   option deprecated = true;
-  repeated ConfigurePWMPinRequest list = 1;
+  repeated ConfigurePWMPinRequest list = 1 [deprecated = true, (nanopb).type = FT_IGNORE];
 }
 
 // Write duty cycle to a pin PWM output pin
@@ -135,10 +135,10 @@ message PWMPinEvent {
   option deprecated = true;
   // Duty cycle between always off (0)
   // and always on (255)
-  int32 duty_cycle        = 2;
+  int32 duty_cycle        = 2 [deprecated = true, (nanopb).type = FT_IGNORE];
 }
 
 message PWMPinEvents {
   option deprecated = true;
-  repeated PWMPinEvent list = 1;
+  repeated PWMPinEvent list = 1 [deprecated = true, (nanopb).type = FT_IGNORE];
 }

--- a/proto/wippersnapper/pwm/v1/pwm.proto
+++ b/proto/wippersnapper/pwm/v1/pwm.proto
@@ -1,0 +1,35 @@
+// SPDX-FileCopyrightText: 2022 Brent Rubell for Adafruit Industries
+// SPDX-License-Identifier: MIT
+syntax = "proto3";
+
+package wippersnapper.pwm.v1;
+import "nanopb/nanopb.proto";
+
+/**
+* WriteDutyCycle represents a request to write a duty cycle to a pin with a frequency (fixed).
+* This is used for controlling LEDs.
+*/
+message WriteDutyCycle {
+  string pin       = 1 [(nanopb).max_size = 6]; /** The pin to write to. */
+  int32 frequency  = 2; /** The PWM frequency, in Hz. This value will not be changed by the slider on Adafruit IO. **/
+  int32 duty_cycle = 3; /** The duty cycle to write. This value will be changed by the slider on Adafruit IO. **/
+  int32 resolution = 4; /** Optional field, sets the resolution fo the analog pin **/
+}
+
+/**
+* WriteFrequency represents a request to write a Frequency, in Hz, to a pin with a duty cycle of 50%.
+* This is used for playing tones using a piezo buzzer or speaker.
+*/
+message WriteFrequency {
+  string pin       = 1 [(nanopb).max_size = 6]; /** The pin to write to. */
+  int32 frequency  = 2; /** The PWM frequency, in Hz. This value will not be changed by the slider on Adafruit IO. **/
+}
+
+/**
+* Deinit represents a request to stop PWM'ing and release the pin for re-use.
+* On ESP32, this will "detach" a pin from a LEDC channel/timer group.
+* On non-ESP32 Arduino, this calls digitalWrite(LOW) on the pin
+*/
+message Deinit {
+  string pin       = 1 [(nanopb).max_size = 6]; /** The PWM pin to de-initialized. */
+}

--- a/proto/wippersnapper/pwm/v1/pwm.proto
+++ b/proto/wippersnapper/pwm/v1/pwm.proto
@@ -17,6 +17,14 @@ message WriteDutyCycle {
 }
 
 /**
+* WriteDutyCycle represents a wrapper request to write duty cycles to multiple pins.
+* This is used for controlling RGB/RGBW LEDs.
+*/
+message WriteDutyCycleMulti {
+  repeated WriteDutyCycle write_duty_cycle = 1 [(nanopb).max_count = 4];
+}
+
+/**
 * WriteFrequency represents a request to write a Frequency, in Hz, to a pin with a duty cycle of 50%.
 * This is used for playing tones using a piezo buzzer or speaker.
 */

--- a/proto/wippersnapper/signal/v1/signal.proto
+++ b/proto/wippersnapper/signal/v1/signal.proto
@@ -74,9 +74,9 @@ message CreateSignalRequest {
     // Update a pins state
     wippersnapper.pin.v1.PinEvent pin_event                             = 15;
     // Create, update or remove a PWM output pin
-    wippersnapper.pin.v1.ConfigurePWMPinRequests pwm_pin_config         = 10 [deprecated = true];
+    wippersnapper.pin.v1.ConfigurePWMPinRequests pwm_pin_config         = 10 [deprecated = true, (nanopb).type = FT_IGNORE];
     // Write duty cycle to a PWM output pin
-    wippersnapper.pin.v1.PWMPinEvents pwm_pin_event                     = 12 [deprecated = true];
+    wippersnapper.pin.v1.PWMPinEvents pwm_pin_event                     = 12 [deprecated = true, (nanopb).type = FT_IGNORE];
     // Update a pin's state
     wippersnapper.pin.v1.PinEvents pin_events                           = 7;
   }

--- a/proto/wippersnapper/signal/v1/signal.proto
+++ b/proto/wippersnapper/signal/v1/signal.proto
@@ -11,6 +11,7 @@ import "nanopb/nanopb.proto";
 import "wippersnapper/pin/v1/pin.proto";
 import "wippersnapper/i2c/v1/i2c.proto";
 import "wippersnapper/servo/v1/servo.proto";
+import "wippersnapper/pwm/v1/pwm.proto";
 
 /**
 * I2CRequest represents the broker's request for a specific i2c command to a device.
@@ -73,9 +74,9 @@ message CreateSignalRequest {
     // Update a pins state
     wippersnapper.pin.v1.PinEvent pin_event                             = 15;
     // Create, update or remove a PWM output pin
-    wippersnapper.pin.v1.ConfigurePWMPinRequests pwm_pin_config         = 10;
+    wippersnapper.pin.v1.ConfigurePWMPinRequests pwm_pin_config         = 10 [deprecated = true];
     // Write duty cycle to a PWM output pin
-    wippersnapper.pin.v1.PWMPinEvents pwm_pin_event                     = 12;
+    wippersnapper.pin.v1.PWMPinEvents pwm_pin_event                     = 12 [deprecated = true];
     // Update a pin's state
     wippersnapper.pin.v1.PinEvents pin_events                           = 7;
   }
@@ -87,5 +88,17 @@ message CreateSignalRequest {
 message SignalResponse {
   oneof payload {
     bool configuration_complete = 1; /** True if a device successfully completed a ConfigurePinRequests message, False otherwise. */
+  }
+}
+
+/**
+* PWMRequest represents a broker's request across the PWM sub-topic.
+*/
+message PWMRequest {
+  option (nanopb_msgopt).submsg_callback = true;
+  oneof payload {
+    wippersnapper.pwm.v1.WriteDutyCycle write_duty_cycle = 1;
+    wippersnapper.pwm.v1.WriteFrequency write_frequency  = 2;
+    wippersnapper.pwm.v1.Deinit deinit                   = 3;
   }
 }

--- a/proto/wippersnapper/signal/v1/signal.proto
+++ b/proto/wippersnapper/signal/v1/signal.proto
@@ -97,8 +97,9 @@ message SignalResponse {
 message PWMRequest {
   option (nanopb_msgopt).submsg_callback = true;
   oneof payload {
-    wippersnapper.pwm.v1.WriteDutyCycle write_duty_cycle = 1;
-    wippersnapper.pwm.v1.WriteFrequency write_frequency  = 2;
-    wippersnapper.pwm.v1.Deinit deinit                   = 3;
+    wippersnapper.pwm.v1.WriteDutyCycle write_duty_cycle            = 1;
+    wippersnapper.pwm.v1.WriteDutyCycleMulti write_duty_cycle_multi = 2;
+    wippersnapper.pwm.v1.WriteFrequency write_frequency             = 3;
+    wippersnapper.pwm.v1.Deinit deinit                              = 4;
   }
 }


### PR DESCRIPTION
Adding PWM API to address https://github.com/adafruit/Wippersnapper_Protobuf/issues/37

Two primary options:
- `WriteDutyCycle`- writes a duty cycle to a pin with a frequency (fixed). Used for LED slider and RGB LED tri-slider.
- `WriteFrequency` - writes a Frequency, in Hz, to a pin with a duty cycle of 50%. Used for piezo buzzers and speakers.

Required before merging:
- [x] PWM component schema  
- [x] Possible we want to define+mark a pin on the board schema as _PWM-compatible_
- [x] Piezo Buzzer component definition
- [x] RGB LED component definition
- [x] PWM LED component definition

@lorennorman  I've marked some of the older prototyping for PWM API within `pin.proto` as deprecated. Do you think we should _delete_ these unused and unreferenced messages instead? 