### PR TITLE
fixing non-deprecated pinevent error

### DIFF
--- a/proto/wippersnapper/pin/v1/pin.proto
+++ b/proto/wippersnapper/pin/v1/pin.proto
@@ -101,7 +101,6 @@ message ConfigureReferenceVoltage {
 * NOTE: Not working with nanopb decode repeated
 */
 message PinEvents {
-  option deprecated = true; 
   repeated PinEvent list = 1 [deprecated = true, (nanopb).type = FT_IGNORE];
 }
 


### PR DESCRIPTION
Fixes error introduced by https://github.com/adafruit/Wippersnapper_Protobuf/pull/100
```
  /home/runner/Arduino/libraries/Adafruit_Wippersnapper_Arduino/src/Wippersnapper.cpp:380:9: error: 'wippersnapper_pin_v1_PinEvents' {aka 'struct _wippersnapper_pin_v1_PinEvents'} has no member named 'list'
       msg.list.funcs.decode = cbDecodePinEventMsg;
           ^~~~
```

https://github.com/adafruit/Adafruit_Wippersnapper_Arduino/runs/8039901651?check_suite_focus=true#step:8:93