### PR TITLE
fix non-dep field but option remains true?

### DIFF
--- a/proto/wippersnapper/pin/v1/pin.proto
+++ b/proto/wippersnapper/pin/v1/pin.proto
@@ -101,7 +101,8 @@ message ConfigureReferenceVoltage {
 * NOTE: Not working with nanopb decode repeated
 */
 message PinEvents {
-  repeated PinEvent list = 1 [deprecated = true, (nanopb).type = FT_IGNORE];
+  option deprecated = true; 
+  repeated PinEvent list = 1;
 }
 
 /* DEPRECATED - PWM Pin API */


### PR DESCRIPTION
Attempting to fix `PinEvent` list field getting removed.

```
typedef struct _wippersnapper_pin_v1_PinEvents {
    char dummy_field;
} wippersnapper_pin_v1_PinEvents;
```