### PR TITLE
Match ServoRequest/ServoResponse

### DIFF
--- a/proto/wippersnapper/servo/v1/servo.proto
+++ b/proto/wippersnapper/servo/v1/servo.proto
@@ -6,9 +6,9 @@ package wippersnapper.servo.v1;
 import "nanopb/nanopb.proto";
 
 /**
-* ServoAttachReq represents a request to attach a servo to a pin.
+* ServoAttachRequest represents a request to attach a servo to a pin.
 */
-message ServoAttachReq {
+message ServoAttachRequest {
   string servo_pin      = 1 [(nanopb).max_size = 6]; /** The name of pin to attach a servo to. */
   int32 servo_freq      = 2; /** The overall PWM frequency, default sent by Adafruit IO is 50Hz. **/
   int32 min_pulse_width = 3; /** The minimum pulse length in uS. Default sent by Adafruit IO is 500uS. **/
@@ -16,17 +16,17 @@ message ServoAttachReq {
 }
 
 /**
-* ServoAttachResp represents the result of attaching a servo to a pin.
+* ServoAttachResponse represents the result of attaching a servo to a pin.
 */
-message ServoAttachResp {
+message ServoAttachResponse {
   bool attach_success = 1; /** True if a servo was attached successfully, False otherwise. **/
   string servo_pin    = 2 [(nanopb).max_size = 6]; /** The name of pin we're responding about. */
 }
 
 /**
-* ServoDetachReq represents request to detach a servo from a pin and de-initialize the pin for other uses.
+* ServoDetachRequest represents a request to detach a servo from a pin and de-initialize the pin for other uses.
 */
-message ServoDetachReq {
+message ServoDetachRequest {
   string servo_pin = 1 [(nanopb).max_size = 5]; /** The name of pin to use as a servo pin. */
 }
 
@@ -37,7 +37,7 @@ message ServoDetachReq {
 * and 2500uS. The client application must convert pulse width to duty cycle w/fixed
 * freq of 50Hz prior to writing to the servo pin.
 */
-message ServoWriteReq {
+message ServoWriteRequest {
   string servo_pin   = 1 [(nanopb).max_size = 5]; /** The name of pin we're addressing. */
   int32  pulse_width = 2; /** The pulse width to write to the servo, in uS **/
 }

--- a/proto/wippersnapper/signal/v1/signal.proto
+++ b/proto/wippersnapper/signal/v1/signal.proto
@@ -50,9 +50,9 @@ message I2CResponse {
 message ServoRequest {
   option (nanopb_msgopt).submsg_callback = true;
   oneof payload {
-    wippersnapper.servo.v1.ServoAttachReq servo_attach = 1;
-    wippersnapper.servo.v1.ServoDetachReq servo_detach = 2;
-    wippersnapper.servo.v1.ServoWriteReq servo_write   = 3;
+    wippersnapper.servo.v1.ServoAttachRequest servo_attach = 1;
+    wippersnapper.servo.v1.ServoDetachRequest servo_detach = 2;
+    wippersnapper.servo.v1.ServoWriteRequest servo_write   = 3;
   }
 }
 
@@ -62,7 +62,7 @@ message ServoRequest {
 message ServoResponse {
   option (nanopb_msgopt).submsg_callback = true;
   oneof payload {
-    wippersnapper.servo.v1.ServoAttachResp servo_attach_resp = 1;
+    wippersnapper.servo.v1.ServoAttachResponse servo_attach_resp = 1;
   }
 }
 

--- a/proto/wippersnapper/signal/v1/signal.proto
+++ b/proto/wippersnapper/signal/v1/signal.proto
@@ -57,9 +57,9 @@ message ServoRequest {
 }
 
 /**
-* ServoResp represents the device's response across the servo sub-topic.
+* ServoResponse represents the device's response across the servo sub-topic.
 */
-message ServoResp {
+message ServoResponse {
   option (nanopb_msgopt).submsg_callback = true;
   oneof payload {
     wippersnapper.servo.v1.ServoAttachResp servo_attach_resp = 1;


### PR DESCRIPTION
Fully expands servo resp to `ServoResponse`, matching `ServoRequest`

Note - this will fail the backward compatibility check but nothing in production is using these messages yet 