### PR TITLE
Update PWM messages

### DIFF
--- a/proto/wippersnapper/pwm/v1/pwm.proto
+++ b/proto/wippersnapper/pwm/v1/pwm.proto
@@ -6,10 +6,39 @@ package wippersnapper.pwm.v1;
 import "nanopb/nanopb.proto";
 
 /**
-* WriteDutyCycle represents a request to write a duty cycle to a pin with a frequency (fixed).
+* AttachRequest represents a request to a device to attach/allocate a PWM pin.
+* On ESP32 Arduino, this will "attach" a pin to a LEDC channel/timer group.
+* On non-ESP32 Arduino, this does nothing.
+*/
+message AttachRequest {
+  string pin       = 1 [(nanopb).max_size = 6]; /** The pin to be attached. */
+  int32 frequency  = 2; /** PWM frequency of an analog pin, in Hz. **/
+  int32 resolution = 3; /** The resolution of an analog pin, in bits. **/
+}
+
+/**
+* AttachResponse represents a response from a device's execution of an
+* AttachRequest message.
+*/
+message AttachResponse {
+  string pin       = 1 [(nanopb).max_size = 6]; /** The requested pin. */
+  bool did_attach = 2; /** True if AttachRequest successful, False otherwise. */
+}
+
+/**
+* DetachRequest represents a request to stop PWM'ing and release the pin for re-use.
+* On ESP32, this will "detach" a pin from a LEDC channel/timer group.
+* On non-ESP32 Arduino, this calls digitalWrite(LOW) on the pin
+*/
+message DetachRequest {
+  string pin       = 1 [(nanopb).max_size = 6]; /** The PWM pin to de-initialized. */
+}
+
+/**
+* WriteDutyCycleRequest represents a request to write a duty cycle to a pin with a frequency (fixed).
 * This is used for controlling LEDs.
 */
-message WriteDutyCycle {
+message WriteDutyCycleRequest {
   string pin       = 1 [(nanopb).max_size = 6]; /** The pin to write to. */
   int32 frequency  = 2; /** The PWM frequency, in Hz. This value will not be changed by the slider on Adafruit IO. **/
   int32 duty_cycle = 3; /** The duty cycle to write. This value will be changed by the slider on Adafruit IO. **/
@@ -20,24 +49,15 @@ message WriteDutyCycle {
 * WriteDutyCycle represents a wrapper request to write duty cycles to multiple pins.
 * This is used for controlling RGB/RGBW LEDs.
 */
-message WriteDutyCycleMulti {
-  repeated WriteDutyCycle write_duty_cycle = 1 [(nanopb).max_count = 4];
+message WriteDutyCycleMultiRequest {
+  repeated WriteDutyCycleRequest write_duty_cycle_req = 1 [(nanopb).max_count = 4];
 }
 
 /**
-* WriteFrequency represents a request to write a Frequency, in Hz, to a pin with a duty cycle of 50%.
+* WriteFrequencyRequest represents a request to write a Frequency, in Hz, to a pin with a duty cycle of 50%.
 * This is used for playing tones using a piezo buzzer or speaker.
 */
-message WriteFrequency {
+message WriteFrequencyRequest {
   string pin       = 1 [(nanopb).max_size = 6]; /** The pin to write to. */
   int32 frequency  = 2; /** The PWM frequency, in Hz. This value will not be changed by the slider on Adafruit IO. **/
-}
-
-/**
-* Deinit represents a request to stop PWM'ing and release the pin for re-use.
-* On ESP32, this will "detach" a pin from a LEDC channel/timer group.
-* On non-ESP32 Arduino, this calls digitalWrite(LOW) on the pin
-*/
-message Deinit {
-  string pin       = 1 [(nanopb).max_size = 6]; /** The PWM pin to de-initialized. */
 }

--- a/proto/wippersnapper/signal/v1/signal.proto
+++ b/proto/wippersnapper/signal/v1/signal.proto
@@ -97,9 +97,20 @@ message SignalResponse {
 message PWMRequest {
   option (nanopb_msgopt).submsg_callback = true;
   oneof payload {
-    wippersnapper.pwm.v1.WriteDutyCycle write_duty_cycle            = 1;
-    wippersnapper.pwm.v1.WriteDutyCycleMulti write_duty_cycle_multi = 2;
-    wippersnapper.pwm.v1.WriteFrequency write_frequency             = 3;
-    wippersnapper.pwm.v1.Deinit deinit                              = 4;
+    wippersnapper.pwm.v1.AttachRequest attach_request                        = 1;
+    wippersnapper.pwm.v1.DetachRequest detach_request                        = 2;
+    wippersnapper.pwm.v1.WriteDutyCycleRequest write_duty_request            = 3;
+    wippersnapper.pwm.v1.WriteDutyCycleMultiRequest write_duty_multi_request = 4;
+    wippersnapper.pwm.v1.WriteFrequencyRequest write_freq_request            = 5;
+  }
+}
+
+/**
+* PWMRequest represents a devices's response across the PWM sub-topic.
+*/
+message PWMResponse {
+  option (nanopb_msgopt).submsg_callback = true;
+  oneof payload {
+    wippersnapper.pwm.v1.AttachResponse attach_response = 1;
   }
 }


### PR DESCRIPTION
Updates `pwm.proto`:
* Adds new `AttachRequest` message for "attaching" a PWM pin and requesting a specific frequency/resolution  (ESP32-Only)
  * Removes redundant handling code for tone/analogWrite to also check for an empty channel/pin and attach, `AttachRequest` is performed first by clicking the "Create New Component" button instead. 
* Adds `AttachResponse` message for handling a PWM Pin attachment, failure if ledc channels are all in-use or requested PWM/resolution is too high.
* Renames all message within `pwm.proto` to request or response, matching work done elsewhere in the API.

**these changes are breaking, however, we do not have pwm hooked up in broker or device yet.**