### PR TITLE
Match PWM Message Style with Servo Message

### DIFF
--- a/proto/wippersnapper/pwm/v1/pwm.proto
+++ b/proto/wippersnapper/pwm/v1/pwm.proto
@@ -6,31 +6,31 @@ package wippersnapper.pwm.v1;
 import "nanopb/nanopb.proto";
 
 /**
-* AttachRequest represents a request to a device to attach/allocate a PWM pin.
+* PWMAttachRequest represents a request to a device to attach/allocate a PWM pin.
 * On ESP32 Arduino, this will "attach" a pin to a LEDC channel/timer group.
 * On non-ESP32 Arduino, this does nothing.
 */
-message AttachRequest {
+message PWMAttachRequest {
   string pin       = 1 [(nanopb).max_size = 6]; /** The pin to be attached. */
   int32 frequency  = 2; /** PWM frequency of an analog pin, in Hz. **/
   int32 resolution = 3; /** The resolution of an analog pin, in bits. **/
 }
 
 /**
-* AttachResponse represents a response from a device's execution of an
+* PWMAttachResponse represents a response from a device's execution of an
 * AttachRequest message.
 */
-message AttachResponse {
+message PWMAttachResponse {
   string pin       = 1 [(nanopb).max_size = 6]; /** The requested pin. */
   bool did_attach = 2; /** True if AttachRequest successful, False otherwise. */
 }
 
 /**
-* DetachRequest represents a request to stop PWM'ing and release the pin for re-use.
+* PWMDetachRequest represents a request to stop PWM'ing and release the pin for re-use.
 * On ESP32, this will "detach" a pin from a LEDC channel/timer group.
 * On non-ESP32 Arduino, this calls digitalWrite(LOW) on the pin
 */
-message DetachRequest {
+message PWMDetachRequest {
   string pin       = 1 [(nanopb).max_size = 6]; /** The PWM pin to de-initialized. */
 }
 
@@ -38,7 +38,7 @@ message DetachRequest {
 * WriteDutyCycleRequest represents a request to write a duty cycle to a pin with a frequency (fixed).
 * This is used for controlling LEDs.
 */
-message WriteDutyCycleRequest {
+message PWMWriteDutyCycleRequest {
   string pin       = 1 [(nanopb).max_size = 6]; /** The pin to write to. */
   int32 frequency  = 2; /** The PWM frequency, in Hz. This value will not be changed by the slider on Adafruit IO. **/
   int32 duty_cycle = 3; /** The duty cycle to write. This value will be changed by the slider on Adafruit IO. **/
@@ -49,15 +49,15 @@ message WriteDutyCycleRequest {
 * WriteDutyCycle represents a wrapper request to write duty cycles to multiple pins.
 * This is used for controlling RGB/RGBW LEDs.
 */
-message WriteDutyCycleMultiRequest {
-  repeated WriteDutyCycleRequest write_duty_cycle_req = 1 [(nanopb).max_count = 4];
+message PWMWriteDutyCycleMultiRequest {
+  repeated PWMWriteDutyCycleRequest write_duty_cycle_req = 1 [(nanopb).max_count = 4];
 }
 
 /**
 * WriteFrequencyRequest represents a request to write a Frequency, in Hz, to a pin with a duty cycle of 50%.
 * This is used for playing tones using a piezo buzzer or speaker.
 */
-message WriteFrequencyRequest {
+message PWMWriteFrequencyRequest {
   string pin       = 1 [(nanopb).max_size = 6]; /** The pin to write to. */
   int32 frequency  = 2; /** The PWM frequency, in Hz. This value will not be changed by the slider on Adafruit IO. **/
 }

--- a/proto/wippersnapper/signal/v1/signal.proto
+++ b/proto/wippersnapper/signal/v1/signal.proto
@@ -97,11 +97,11 @@ message SignalResponse {
 message PWMRequest {
   option (nanopb_msgopt).submsg_callback = true;
   oneof payload {
-    wippersnapper.pwm.v1.AttachRequest attach_request                        = 1;
-    wippersnapper.pwm.v1.DetachRequest detach_request                        = 2;
-    wippersnapper.pwm.v1.WriteDutyCycleRequest write_duty_request            = 3;
-    wippersnapper.pwm.v1.WriteDutyCycleMultiRequest write_duty_multi_request = 4;
-    wippersnapper.pwm.v1.WriteFrequencyRequest write_freq_request            = 5;
+    wippersnapper.pwm.v1.PWMAttachRequest attach_request                        = 1;
+    wippersnapper.pwm.v1.PWMDetachRequest detach_request                        = 2;
+    wippersnapper.pwm.v1.PWMWriteDutyCycleRequest write_duty_request            = 3;
+    wippersnapper.pwm.v1.PWMWriteDutyCycleMultiRequest write_duty_multi_request = 4;
+    wippersnapper.pwm.v1.PWMWriteFrequencyRequest write_freq_request            = 5;
   }
 }
 
@@ -111,6 +111,6 @@ message PWMRequest {
 message PWMResponse {
   option (nanopb_msgopt).submsg_callback = true;
   oneof payload {
-    wippersnapper.pwm.v1.AttachResponse attach_response = 1;
+    wippersnapper.pwm.v1.PWMAttachResponse attach_response = 1;
   }
 }


### PR DESCRIPTION
Resolves @lorennorman 's comment on https://github.com/adafruit/Wippersnapper_Protobuf/pull/106#discussion_r961135403
> I would like to match the style used by servo.proto here and call these: `PWMAttachRequest`, `PWMAttachResponse` and `PWMDetachResponse`, if possible.

