### PR TITLE
Add I2CDeviceSensorProperties to DS18x20 API

### DIFF
--- a/proto/wippersnapper/ds18x20/v1/ds18x20.proto
+++ b/proto/wippersnapper/ds18x20/v1/ds18x20.proto
@@ -5,6 +5,7 @@
 syntax = "proto3";
 
 package wippersnapper.ds18x20.v1;
+import "nanopb/nanopb.proto";
 import "wippersnapper/i2c/v1/i2c.proto";
 
 /**
@@ -13,9 +14,10 @@ import "wippersnapper/i2c/v1/i2c.proto";
 * NOTE: This API only supports ONE DS18X20 device PER OneWire bus.
 */
 message Ds18x20InitRequest {
-  int32  onewire_pin        = 1; /** The desired pin to use as a OneWire bus. */
-  uint32 sensor_period      = 2; /** The desired amount of time between sensor reads. */
-  int32  sensor_resolution  = 3; /** The desired sensor resolution (9, 10, 11, or 12 bits). */
+  int32  onewire_pin                                        = 1; /** The desired pin to use as a OneWire bus. */
+  uint32 sensor_period                                      = 2; /** The desired amount of time between sensor reads. */
+  int32  sensor_resolution                                  = 3; /** The desired sensor resolution (9, 10, 11, or 12 bits). */
+  repeated wippersnapper.i2c.v1.I2CDeviceSensorProperties i2c_device_properties  = 4[(nanopb).max_count = 2]; /** Properties for the DS18x20 sensor. */
 }
 
 /**

--- a/proto/wippersnapper/ds18x20/v1/ds18x20.proto
+++ b/proto/wippersnapper/ds18x20/v1/ds18x20.proto
@@ -14,7 +14,7 @@ import "wippersnapper/i2c/v1/i2c.proto";
 * NOTE: This API only supports ONE DS18X20 device PER OneWire bus.
 */
 message Ds18x20InitRequest {
-  int32  onewire_pin                                                             = 1; /** The desired pin to use as a OneWire bus. */
+  string onewire_pin                                                             = 1 [(nanopb).max_size = 5]; /** The desired pin to use as a OneWire bus. */
   int32  sensor_resolution                                                       = 2; /** The desired sensor resolution (9, 10, 11, or 12 bits). */
   repeated wippersnapper.i2c.v1.I2CDeviceSensorProperties i2c_device_properties  = 3[(nanopb).max_count = 2]; /** Properties for the DS18x20 sensor. */
 }
@@ -25,7 +25,7 @@ message Ds18x20InitRequest {
 */
 message Ds18x20InitResponse {
   bool is_initialized  = 1; /** True if the 1-wire bus has been initialized successfully, False otherwise. */
-  int32  onewire_pin   = 2; /** The desired pin to use as a OneWire bus. */
+  string onewire_pin   = 2 [(nanopb).max_size = 5]; /** The pin being used as a OneWire bus. */
 }
 
 /**
@@ -33,13 +33,13 @@ message Ds18x20InitResponse {
 * Maxim temperature sensor, from the broker.
 */
 message Ds18x20DeInitRequest {
-  int32  onewire_pin        = 1; /** The desired pin to use as a OneWire bus. */
+  string onewire_pin  = 1 [(nanopb).max_size = 5]; /** The desired onewire bus to de-initialize a DS18x sensor on and release. */
 }
 
 /**
 * Ds18x20DeviceEvent event represents data from **one** DS18X20 sensor.
 */
 message Ds18x20DeviceEvent {
-  int32 onewire_pin                              = 1; /** The desired pin to use as a OneWire bus. */
+  string onewire_pin                             = 1 [(nanopb).max_size = 5]; /** The desired pin to use as a OneWire bus. */
   wippersnapper.i2c.v1.SensorEvent sensor_event  = 2; /** The DS18X20's SensorEvent. */
 }

--- a/proto/wippersnapper/ds18x20/v1/ds18x20.proto
+++ b/proto/wippersnapper/ds18x20/v1/ds18x20.proto
@@ -14,10 +14,9 @@ import "wippersnapper/i2c/v1/i2c.proto";
 * NOTE: This API only supports ONE DS18X20 device PER OneWire bus.
 */
 message Ds18x20InitRequest {
-  int32  onewire_pin                                        = 1; /** The desired pin to use as a OneWire bus. */
-  uint32 sensor_period                                      = 2; /** The desired amount of time between sensor reads. */
-  int32  sensor_resolution                                  = 3; /** The desired sensor resolution (9, 10, 11, or 12 bits). */
-  repeated wippersnapper.i2c.v1.I2CDeviceSensorProperties i2c_device_properties  = 4[(nanopb).max_count = 2]; /** Properties for the DS18x20 sensor. */
+  int32  onewire_pin                                                             = 1; /** The desired pin to use as a OneWire bus. */
+  int32  sensor_resolution                                                       = 2; /** The desired sensor resolution (9, 10, 11, or 12 bits). */
+  repeated wippersnapper.i2c.v1.I2CDeviceSensorProperties i2c_device_properties  = 3[(nanopb).max_count = 2]; /** Properties for the DS18x20 sensor. */
 }
 
 /**


### PR DESCRIPTION
Adding `I2CDeviceSensorProperties` field to DS18x20 initialization call to bring it in-line with current I2C work.