### PR TITLE
Adds reuseable workflow

### DIFF
--- a/.github/workflows/buf-checks.yml
+++ b/.github/workflows/buf-checks.yml
@@ -6,7 +6,7 @@ on:
       GH_REPO_TOKEN:
         required: true
 jobs:
-  build:
+  lint-compatibility-check:
     runs-on: ubuntu-latest
     steps:
       - name: checkout

--- a/.github/workflows/buf-checks.yml
+++ b/.github/workflows/buf-checks.yml
@@ -1,5 +1,4 @@
 name: Linting and Backwards-Compatibility Checks
-# on: [ push ]
 on:
   workflow_call:
     secrets:

--- a/.github/workflows/buf-checks.yml
+++ b/.github/workflows/buf-checks.yml
@@ -1,5 +1,9 @@
 name: Linting and Backwards-Compatibility Checks
 # on: [ push ]
+  workflow_call:
+    secrets:
+      GH_REPO_TOKEN:
+        required: true
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/buf-checks.yml
+++ b/.github/workflows/buf-checks.yml
@@ -1,5 +1,6 @@
 name: Linting and Backwards-Compatibility Checks
 # on: [ push ]
+on:
   workflow_call:
     secrets:
       GH_REPO_TOKEN:

--- a/.github/workflows/buf-checks.yml
+++ b/.github/workflows/buf-checks.yml
@@ -1,5 +1,5 @@
 name: Linting and Backwards-Compatibility Checks
-on: [ push ]
+# on: [ push ]
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint-and-generate.yml
+++ b/.github/workflows/lint-and-generate.yml
@@ -24,3 +24,4 @@ jobs:
     uses: brentru/Wippersnapper_Protobuf-1/.github/workflows/protoc-wrapper-generation.yml@reuseable-workflow
     secrets:
       token: ${{ secrets.GH_REPO_TOKEN }}
+      GITHUB_TOKEN: ${{ secrets.GH_REPO_TOKEN }}

--- a/.github/workflows/lint-and-generate.yml
+++ b/.github/workflows/lint-and-generate.yml
@@ -20,4 +20,5 @@ jobs:
     needs: lint
     uses: brentru/Wippersnapper_Protobuf-1/.github/workflows/protoc-wrapper-generation.yml@reuseable-workflow
     secrets:
-      GH_REPO_TOKEN: ${{ secrets.GH_REPO_TOKEN }}
+      GH_REPO_TOKEN: ${{ secrets.IO_BOT_PAT }}
+      

--- a/.github/workflows/lint-and-generate.yml
+++ b/.github/workflows/lint-and-generate.yml
@@ -5,17 +5,12 @@
 name: WipperSnapper Protocol Buffer CI (caller workflow)
 
 on:
-  push:
   pull_request:
     branches: master
     secrets:
       GH_REPO_TOKEN:
         required: true
   push:
-    branches: master
-      secrets:
-        GH_REPO_TOKEN:
-          required: true
 
 jobs:
   lint:

--- a/.github/workflows/lint-and-generate.yml
+++ b/.github/workflows/lint-and-generate.yml
@@ -1,7 +1,6 @@
 # SPDX-FileCopyrightText: Brent Rubell for Adafruit Industries, 2022
 #
 # SPDX-License-Identifier: MIT
-
 name: WipperSnapper Protocol Buffer CI (caller workflow)
 
 on:
@@ -14,11 +13,11 @@ on:
 
 jobs:
   lint:
-    uses: brentru/Wippersnapper_Protobuf/.github/workflows/buf-checks.yml@master
+    uses: brentru/Wippersnapper_Protobuf/.github/workflows/buf-checks.yml@reusable-workflow
     secrets:
       GH_REPO_TOKEN: ${{ secrets.GH_REPO_TOKEN }}
   generate:
     needs: lint
-    uses: brentru/Wippersnapper_Protobuf/.github/workflows/protoc-wrapper-generation.yml@master
+    uses: brentru/Wippersnapper_Protobuf/.github/workflows/protoc-wrapper-generation.yml@reusable-workflow
     secrets:
       GH_REPO_TOKEN: ${{ secrets.GH_REPO_TOKEN }}

--- a/.github/workflows/lint-and-generate.yml
+++ b/.github/workflows/lint-and-generate.yml
@@ -1,0 +1,27 @@
+# SPDX-FileCopyrightText: Brent Rubell for Adafruit Industries, 2022
+#
+# SPDX-License-Identifier: MIT
+
+name: WipperSnapper Protocol Buffer CI
+
+on:
+  pull_request:
+    secrets:
+      GH_REPO_TOKEN:
+        required: true
+  push:
+    branches: master
+      secrets:
+        GH_REPO_TOKEN:
+          required: true
+
+jobs:
+  lint:
+    uses: adafruit/Wippersnapper_Protobuf/.github/workflows/buf-checks.yml@master
+    secrets:
+      GH_REPO_TOKEN: ${{ secrets.GH_REPO_TOKEN }}
+  generate:
+    needs: lint
+    uses: adafruit/Wippersnapper_Protobuf/.github/workflows/protoc-wrapper-generation.yml@master
+    secrets:
+      GH_REPO_TOKEN: ${{ secrets.GH_REPO_TOKEN }}

--- a/.github/workflows/lint-and-generate.yml
+++ b/.github/workflows/lint-and-generate.yml
@@ -2,10 +2,12 @@
 #
 # SPDX-License-Identifier: MIT
 
-name: WipperSnapper Protocol Buffer CI
+name: WipperSnapper Protocol Buffer CI (caller workflow)
 
 on:
+  push:
   pull_request:
+    branches: master
     secrets:
       GH_REPO_TOKEN:
         required: true

--- a/.github/workflows/lint-and-generate.yml
+++ b/.github/workflows/lint-and-generate.yml
@@ -13,11 +13,11 @@ on:
 
 jobs:
   lint:
-    uses: brentru/Wippersnapper_Protobuf-1/.github/workflows/buf-checks.yml@reusable-workflow
+    uses: brentru/Wippersnapper_Protobuf-1/.github/workflows/buf-checks.yml@reuseable-workflow
     secrets:
       GH_REPO_TOKEN: ${{ secrets.GH_REPO_TOKEN }}
   generate:
     needs: lint
-    uses: brentru/Wippersnapper_Protobuf-1/.github/workflows/protoc-wrapper-generation.yml@reusable-workflow
+    uses: brentru/Wippersnapper_Protobuf-1/.github/workflows/protoc-wrapper-generation.yml@reuseable-workflow
     secrets:
       GH_REPO_TOKEN: ${{ secrets.GH_REPO_TOKEN }}

--- a/.github/workflows/lint-and-generate.yml
+++ b/.github/workflows/lint-and-generate.yml
@@ -13,11 +13,11 @@ on:
 
 jobs:
   lint:
-    uses: brentru/Wippersnapper_Protobuf/.github/workflows/buf-checks.yml@reusable-workflow
+    uses: brentru/Wippersnapper_Protobuf-1/.github/workflows/buf-checks.yml@reusable-workflow
     secrets:
       GH_REPO_TOKEN: ${{ secrets.GH_REPO_TOKEN }}
   generate:
     needs: lint
-    uses: brentru/Wippersnapper_Protobuf/.github/workflows/protoc-wrapper-generation.yml@reusable-workflow
+    uses: brentru/Wippersnapper_Protobuf-1/.github/workflows/protoc-wrapper-generation.yml@reusable-workflow
     secrets:
       GH_REPO_TOKEN: ${{ secrets.GH_REPO_TOKEN }}

--- a/.github/workflows/lint-and-generate.yml
+++ b/.github/workflows/lint-and-generate.yml
@@ -14,11 +14,8 @@ on:
 jobs:
   lint:
     uses: brentru/Wippersnapper_Protobuf-1/.github/workflows/buf-checks.yml@reuseable-workflow
-    secrets:
-      GH_REPO_TOKEN: ${{ secrets.GH_REPO_TOKEN }}
   generate:
     needs: lint
     uses: brentru/Wippersnapper_Protobuf-1/.github/workflows/protoc-wrapper-generation.yml@reuseable-workflow
     secrets:
-      GH_REPO_TOKEN: ${{ secrets.IO_BOT_PAT }}
-      
+      GH_REPO_TOKEN: ${{ secrets.GH_REPO_TOKEN }}

--- a/.github/workflows/lint-and-generate.yml
+++ b/.github/workflows/lint-and-generate.yml
@@ -10,6 +10,9 @@ on:
       GH_REPO_TOKEN:
         required: true
   push:
+    secrets:
+      GH_REPO_TOKEN:
+        required: true
 
 jobs:
   lint:

--- a/.github/workflows/lint-and-generate.yml
+++ b/.github/workflows/lint-and-generate.yml
@@ -23,4 +23,4 @@ jobs:
     needs: lint
     uses: brentru/Wippersnapper_Protobuf-1/.github/workflows/protoc-wrapper-generation.yml@reuseable-workflow
     secrets:
-      GH_REPO_TOKEN: ${{ secrets.GH_REPO_TOKEN }}
+      token: ${{ secrets.GH_REPO_TOKEN }}

--- a/.github/workflows/lint-and-generate.yml
+++ b/.github/workflows/lint-and-generate.yml
@@ -14,11 +14,11 @@ on:
 
 jobs:
   lint:
-    uses: adafruit/Wippersnapper_Protobuf/.github/workflows/buf-checks.yml@master
+    uses: brentru/Wippersnapper_Protobuf/.github/workflows/buf-checks.yml@master
     secrets:
       GH_REPO_TOKEN: ${{ secrets.GH_REPO_TOKEN }}
   generate:
     needs: lint
-    uses: adafruit/Wippersnapper_Protobuf/.github/workflows/protoc-wrapper-generation.yml@master
+    uses: brentru/Wippersnapper_Protobuf/.github/workflows/protoc-wrapper-generation.yml@master
     secrets:
       GH_REPO_TOKEN: ${{ secrets.GH_REPO_TOKEN }}

--- a/.github/workflows/lint-and-generate.yml
+++ b/.github/workflows/lint-and-generate.yml
@@ -4,24 +4,19 @@
 name: WipperSnapper Protocol Buffer CI (caller workflow)
 
 on:
-  pull_request:
-    branches: master
-    secrets:
-      GH_REPO_TOKEN:
-        required: true
   push:
+    branches: master
     secrets:
       GH_REPO_TOKEN:
         required: true
 
 jobs:
   lint:
-    uses: brentru/Wippersnapper_Protobuf-1/.github/workflows/buf-checks.yml@reuseable-workflow
+    uses: adafruit/Wippersnapper_Protobuf/.github/workflows/buf-checks.yml@master
     secrets:
       GH_REPO_TOKEN: ${{ secrets.GH_REPO_TOKEN }}
   generate:
     needs: lint
-    uses: brentru/Wippersnapper_Protobuf-1/.github/workflows/protoc-wrapper-generation.yml@reuseable-workflow
+    uses: adafruit/Wippersnapper_Protobuf/.github/workflows/protoc-wrapper-generation.yml@master
     secrets:
-      token: ${{ secrets.GH_REPO_TOKEN }}
       GITHUB_TOKEN: ${{ secrets.GH_REPO_TOKEN }}

--- a/.github/workflows/lint-and-generate.yml
+++ b/.github/workflows/lint-and-generate.yml
@@ -17,6 +17,8 @@ on:
 jobs:
   lint:
     uses: brentru/Wippersnapper_Protobuf-1/.github/workflows/buf-checks.yml@reuseable-workflow
+    secrets:
+      GH_REPO_TOKEN: ${{ secrets.GH_REPO_TOKEN }}
   generate:
     needs: lint
     uses: brentru/Wippersnapper_Protobuf-1/.github/workflows/protoc-wrapper-generation.yml@reuseable-workflow

--- a/.github/workflows/protoc-wrapper-generation.yml
+++ b/.github/workflows/protoc-wrapper-generation.yml
@@ -1,7 +1,8 @@
 name: Generate .proto Wrapper Files
-# on:
+#on:
 #  push:
 #    branches: master
+on:
   workflow_call:
     secrets:
       GH_REPO_TOKEN:

--- a/.github/workflows/protoc-wrapper-generation.yml
+++ b/.github/workflows/protoc-wrapper-generation.yml
@@ -1,7 +1,11 @@
 name: Generate .proto Wrapper Files
-on:
-  push:
-    branches: master
+# on:
+#  push:
+#    branches: master
+  workflow_call:
+    secrets:
+      GH_REPO_TOKEN:
+        required: true
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/protoc-wrapper-generation.yml
+++ b/.github/workflows/protoc-wrapper-generation.yml
@@ -1,7 +1,4 @@
 name: Generate .proto Wrapper Files
-#on:
-#  push:
-#    branches: master
 on:
   workflow_call:
     secrets:


### PR DESCRIPTION
Solves the first bullet point from issue https://github.com/adafruit/Wippersnapper_Protobuf/issues/105 by creating a reusable workflow and having the build action depend upon the backward compatibility action passing.

> [buf-checks.yml](https://github.com/adafruit/Wippersnapper_Protobuf/blob/master/.github/workflows/buf-checks.yml) should be run prior to [protoc-wrapper-generation.yml](https://github.com/adafruit/Wippersnapper_Protobuf/blob/master/.github/workflows/protoc-wrapper-generation.yml). Currently, they run independently of each other, letting a file without backward-compatibility get generated and deployed to multiple repositories. This is still useful when working on new message types, but harmful when updating existing ones.

@lorennorman  We may want to wait on adding this to the repo because requiring backward-compat. first, while we're still in beta (and breaking things) may cause release issues/delays. Could also modify `on:`, not sure how you'd like to proceed. 