### PR TITLE
Add documentation for pwm.proto

### DIFF
--- a/proto/wippersnapper/pwm/v1/pwm.md
+++ b/proto/wippersnapper/pwm/v1/pwm.md
@@ -1,0 +1,135 @@
+
+# pixels.proto
+
+This file details the WipperSnapper messaging API for interfacing with PWM output components.
+
+PWM components either have a fixed frequency with a variable duty cycle _or_ a variable frequency with a fixed duty cycle.
+
+## WipperSnapper Components
+
+The following WipperSnapper components utilize `pwm.proto`:
+
+* Dimmable LED (Fixed Frequency, variable Duty Cycle)
+
+* Piezo Buzzer (Variable Frequency, fixed Duty Cycle)
+
+
+## Sequence Diagrams
+
+### Create: Dimmable LED
+
+```mermaid
+sequenceDiagram
+autonumber
+
+IO-->>Device: PWMAttachRequest
+Note over IO, Device: Contains:<br> `pin` according to form<br>`frequency` of 5000Hz<br> `resolution` of 12 bits
+
+Device->>IO: PWMAttachResponse
+Note over IO, Device: Contains:<br> `pin` from <br>corresponding PWMAttachRequest msg. <br>`did_attach` True if attached.
+```
+
+
+### Write: Dimmable LED
+```mermaid
+sequenceDiagram
+autonumber
+IO->>Device: PWMWriteDutyCycleRequest
+Note over IO, Device: The duty_cycle (0->255) from the <br>IO slider widget is written to the `pin`.
+```
+
+### Update: Dimmable LED
+```mermaid
+sequenceDiagram
+autonumber
+IO->>Device: PWMDetachRequest
+Note over IO, Device: Detaches GPIO pin from a timer
+
+IO-->>Device: PWMAttachRequest
+Note over IO, Device: Contains:<br> `pin` according to form<br>`frequency` of 5000Hz<br> `resolution` of 12 bits
+
+Device->>IO: PWMAttachResponse
+Note over IO, Device: Contains:<br> `pin` from <br>corresponding PWMAttachRequest msg. <br>`did_attach` True if attached.
+```
+
+### Delete: Dimmable LED
+```mermaid
+sequenceDiagram
+autonumber
+IO->>Device: PWMDetachRequest
+Note over IO, Device: Detaches GPIO pin from a timer
+```
+
+### Sync: Dimmable LED
+```mermaid
+sequenceDiagram
+autonumber
+
+IO-->>Device: PWMAttachRequest
+Note over IO, Device: Contains:<br> `pin` according to DB<br>`frequency` of 5000Hz<br> `resolution` of 12 bits
+
+Device->>IO: PWMAttachResponse
+Note over IO, Device: Contains:<br> `pin` from <br>corresponding PWMAttachRequest msg. <br>`did_attach` True if attached.
+
+IO->>Device: PWMWriteDutyCycleRequest
+Note over IO, Device: duty_cycle (0->255) from IO feed's last_value.
+```
+
+### Create: Piezo Buzzer
+
+```mermaid
+sequenceDiagram
+autonumber
+
+IO-->>Device: PWMAttachRequest
+Note over IO, Device: Contains:<br> `pin` according to form<br>`frequency` of 0Hz<br> `resolution` of 12 bits
+
+Device->>IO: PWMAttachResponse
+Note over IO, Device: Contains:<br> `pin` from <br>corresponding PWMAttachRequest msg. <br>`did_attach` True if attached.
+```
+
+
+### Write: Piezo Buzzer
+```mermaid
+sequenceDiagram
+autonumber
+IO->>Device: PWMWriteFrequencyRequest
+Note over IO, Device: Any frequency > 0Hz to play a tone, 0Hz to turn off
+```
+
+### Update: Piezo Buzzer
+```mermaid
+sequenceDiagram
+autonumber
+IO->>Device: PWMDetachRequest
+Note over IO, Device: Detaches GPIO pin from a timer
+
+IO-->>Device: PWMAttachRequest
+Note over IO, Device: Contains:<br> `pin` according to form<br>`frequency` of 0Hz<br> `resolution` of 12 bits
+
+Device->>IO: PWMAttachResponse
+Note over IO, Device: Contains:<br> `pin` from <br>corresponding PWMAttachRequest msg. <br>`did_attach` True if attached.
+```
+
+### Delete: Piezo Buzzer
+```mermaid
+sequenceDiagram
+autonumber
+IO->>Device: PWMDetachRequest
+Note over IO, Device: Detaches GPIO pin from a timer
+```
+
+### Sync: Piezo Buzzer
+```mermaid
+sequenceDiagram
+autonumber
+
+IO-->>Device: PWMAttachRequest
+Note over IO, Device: Contains:<br> `pin` according to DB<br>`frequency` of 0Hz<br> `resolution` of 12 bits
+
+Device->>IO: PWMAttachResponse
+Note over IO, Device: Contains:<br> `pin` from <br>corresponding PWMAttachRequest msg. <br>`did_attach` True if attached.
+
+IO->>Device: PWMWriteFrequencyRequest
+Note over IO, Device: frequency, in Hz, from IO feed's last_value.
+```


### PR DESCRIPTION
* Adds .md file with documentation for the WipperSnapper messaging API for interfacing with PWM output components.