### PR TITLE
Add a cross-workflow build for WipperSnapper firmware

### DIFF
--- a/.github/workflows/test-wrapper-arduino.yml
+++ b/.github/workflows/test-wrapper-arduino.yml
@@ -52,12 +52,12 @@ jobs:
       uses: actions/checkout@v2
       with:
         repository: adafruit/Adafruit_Wippersnapper_Arduino
-        path: arduino-checkout
+#        path: arduino-checkout
     - name: Copy Generated Arduino Files to Arduino Repo
       run: |
-        rm -rf ./arduino-checkout/src/wippersnapper/
-        mkdir ./arduino-checkout/src/wippersnapper/
-        cp -a ./arduino_out/. ./arduino-checkout/src/
+        rm -rf /src/wippersnapper/
+        mkdir /src/wippersnapper/
+        cp -a ./arduino_out/. ./src/
     - name: Install extra Arduino libraries
       run: |
         git clone --quiet https://github.com/brentru/Adafruit_MQTT_Library.git /home/runner/Arduino/libraries/Adafruit_MQTT_Library

--- a/.github/workflows/test-wrapper-arduino.yml
+++ b/.github/workflows/test-wrapper-arduino.yml
@@ -50,7 +50,7 @@ jobs:
       run: ls -d */
     - name: Copy Generated Arduino Files to Arduino Repo
       run: |
-        cp -a /Adafruit_Wippersnapper_Arduino/. .
+        cp -a ./Adafruit_Wippersnapper_Arduino/ .
         rm -rf ./src/wippersnapper/
         mkdir ./src/wippersnapper/
         cp -a ./arduino_out/. ./src/wippersnapper

--- a/.github/workflows/test-wrapper-arduino.yml
+++ b/.github/workflows/test-wrapper-arduino.yml
@@ -64,7 +64,9 @@ jobs:
         git clone --quiet https://github.com/brentru/Adafruit_MQTT_Library.git /home/runner/Arduino/libraries/Adafruit_MQTT_Library
         git clone --quiet https://github.com/milesburton/Arduino-Temperature-Control-Library.git /home/runner/Arduino/libraries/Arduino-Temperature-Control-Library
         git clone --quiet https://github.com/PaulStoffregen/OneWire.git /home/runner/Arduino/libraries/OneWire
-    - name: list
-      run: ls
+    - name: pwd
+      run: pwd
+    - name: list all dirs
+      run: ls -d */
     - name: Test Feather ESP32 Build w/new .proto files
       run: python3 ci/build_platform.py feather_esp32_v2

--- a/.github/workflows/test-wrapper-arduino.yml
+++ b/.github/workflows/test-wrapper-arduino.yml
@@ -1,5 +1,5 @@
 name: Generate new proto wrapper files and test WipperSnapper build
-on: [ pull ]
+on: [ push ]
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-wrapper-arduino.yml
+++ b/.github/workflows/test-wrapper-arduino.yml
@@ -49,7 +49,7 @@ jobs:
     - name: list all dirs
       run: |
         ls -d */
-        ls -d ./arduino_out/
+        ls arduino_out/
     - name: Copy Generated Arduino Files to Arduino Repo
       run: |
         cp -a ./Adafruit_Wippersnapper_Arduino/. .

--- a/.github/workflows/test-wrapper-arduino.yml
+++ b/.github/workflows/test-wrapper-arduino.yml
@@ -1,5 +1,5 @@
 name: Generate new proto wrapper files and test WipperSnapper build
-on: [ push ]
+on: [ pull ]
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-wrapper-arduino.yml
+++ b/.github/workflows/test-wrapper-arduino.yml
@@ -40,7 +40,7 @@ jobs:
         bash ci/actions_install.sh
     - name: Clone Arduino Repo
       run: |
-        git clone --quiet https://github.com/adafruit/Adafruit_Wippersnapper_Arduino.git
+        git clone --quiet https://github.com/adafruit/Adafruit_Wippersnapper_Arduino.git .
     - name: Install Dependencies
       run: |
         pip3 install esptool

--- a/.github/workflows/test-wrapper-arduino.yml
+++ b/.github/workflows/test-wrapper-arduino.yml
@@ -56,6 +56,7 @@ jobs:
         rm -rf ./src/wippersnapper/
         mkdir ./src/wippersnapper/
         cp -a ./arduino_out/. ./src/wippersnapper
+        ls -la ./src/wippersnapper
     - name: Install extra Arduino libraries
       run: |
         git clone --quiet https://github.com/brentru/Adafruit_MQTT_Library.git /home/runner/Arduino/libraries/Adafruit_MQTT_Library

--- a/.github/workflows/test-wrapper-arduino.yml
+++ b/.github/workflows/test-wrapper-arduino.yml
@@ -33,16 +33,14 @@ jobs:
         # Local (non-CI) build command:
         # protoc --plugin=nanopb/generator/protoc-gen-nanopb -Inanopb/generator/proto --proto_path=./proto ./proto/wippersnapper/*/*/*.proto --nanopb_out=./arduino_out --nanopb_opt=-I./proto --nanopb_opt=-t
         pwd
-    - name: Checkout Arduino Repo
-      uses: actions/checkout@v2
-      with:
-        repository: adafruit/Adafruit_Wippersnapper_Arduino
-    - uses: actions/checkout@v2
-      with:
-         repository: adafruit/ci-arduino
-         path: ci
     - name: Install CI-Arduino
-      run: bash ci/actions_install.sh
+      run: |
+        mkdir ./ci/
+        git clone --quiet git@github.com:adafruit/ci-arduino.git ./ci/
+        bash ci/actions_install.sh
+    - name: Clone Arduino Repo
+      run: |
+        git clone --quiet git@github.com:adafruit/Adafruit_Wippersnapper_Arduino.git
     - name: Install Dependencies
       run: |
         pip3 install esptool

--- a/.github/workflows/test-wrapper-arduino.yml
+++ b/.github/workflows/test-wrapper-arduino.yml
@@ -56,7 +56,7 @@ jobs:
         rm -rf ./src/wippersnapper/
         mkdir ./src/wippersnapper/
         cp -a ./arduino_out/. ./src/wippersnapper
-        ls -la ./src/wippersnapper
+        ls -a ./src/wippersnapper
     - name: Install extra Arduino libraries
       run: |
         git clone --quiet https://github.com/brentru/Adafruit_MQTT_Library.git /home/runner/Arduino/libraries/Adafruit_MQTT_Library

--- a/.github/workflows/test-wrapper-arduino.yml
+++ b/.github/workflows/test-wrapper-arduino.yml
@@ -63,7 +63,7 @@ jobs:
         git clone --quiet https://github.com/brentru/Adafruit_MQTT_Library.git /home/runner/Arduino/libraries/Adafruit_MQTT_Library
         git clone --quiet https://github.com/milesburton/Arduino-Temperature-Control-Library.git /home/runner/Arduino/libraries/Arduino-Temperature-Control-Library
         git clone --quiet https://github.com/PaulStoffregen/OneWire.git /home/runner/Arduino/libraries/OneWire
-    - name: cd
-      run: cd ./arduino-checkout/
+#    - name: cd
+#      run: cd ./arduino-checkout/
     - name: Test Feather ESP32 Build w/new .proto files
       run: python3 ci/build_platform.py feather_esp32_v2

--- a/.github/workflows/test-wrapper-arduino.yml
+++ b/.github/workflows/test-wrapper-arduino.yml
@@ -40,7 +40,7 @@ jobs:
         bash ci/actions_install.sh
     - name: Clone Arduino Repo
       run: |
-        git clone --quiet https://github.com/adafruit/Adafruit_Wippersnapper_Arduino.git .
+        git clone --quiet https://github.com/adafruit/Adafruit_Wippersnapper_Arduino.git
     - name: Install Dependencies
       run: |
         pip3 install esptool
@@ -50,6 +50,7 @@ jobs:
       run: ls -d */
     - name: Copy Generated Arduino Files to Arduino Repo
       run: |
+        cp -a /Adafruit_Wippersnapper_Arduino/. .
         rm -rf ./src/wippersnapper/
         mkdir ./src/wippersnapper/
         cp -a ./arduino_out/. ./src/wippersnapper

--- a/.github/workflows/test-wrapper-arduino.yml
+++ b/.github/workflows/test-wrapper-arduino.yml
@@ -39,31 +39,19 @@ jobs:
         protoc --plugin=protobuf-checkout/nanopb/generator/protoc-gen-nanopb -Iprotobuf-checkout/nanopb/generator/proto --proto_path=./protobuf-checkout/proto ./protobuf-checkout/proto/wippersnapper/*/*/*.proto --nanopb_out=./arduino_out --nanopb_opt=-I./protobuf-checkout/proto --nanopb_opt=-t
         # Local (non-CI) build command:
         # protoc --plugin=nanopb/generator/protoc-gen-nanopb -Inanopb/generator/proto --proto_path=./proto ./proto/wippersnapper/*/*/*.proto --nanopb_out=./arduino_out --nanopb_opt=-I./proto --nanopb_opt=-t
+    - name: Checkout Arduino Repo
+      uses: actions/checkout@v2
+      with:
+        repository: adafruit/Adafruit_Wippersnapper_Arduino
     - uses: actions/checkout@v2
       with:
          repository: brentru/ci-arduino
          path: ci
     - name: Install CI-Arduino
       run: bash ci/actions_install.sh
-    - name: list ci
-      run: ls ci
     - name: Install Dependencies
       run: |
         pip3 install esptool
-    - name: Checkout Arduino Repo
-      uses: actions/checkout@v2
-      with:
-        repository: adafruit/Adafruit_Wippersnapper_Arduino
-#    - name: Copy Generated Arduino Files to Arduino Repo
-#      run: |
-#        rm -rf ./arduino-checkout/src/wippersnapper/
-#        mkdir ./arduino-checkout/src/wippersnapper/
-#        cp -a ./arduino_out/. ./arduino-checkout/src/
-    - name: Install extra Arduino libraries
-      run: |
-        git clone --quiet https://github.com/brentru/Adafruit_MQTT_Library.git /home/runner/Arduino/libraries/Adafruit_MQTT_Library
-        git clone --quiet https://github.com/milesburton/Arduino-Temperature-Control-Library.git /home/runner/Arduino/libraries/Arduino-Temperature-Control-Library
-        git clone --quiet https://github.com/PaulStoffregen/OneWire.git /home/runner/Arduino/libraries/OneWire
     - name: pwd
       run: pwd
     - name: list all dirs

--- a/.github/workflows/test-wrapper-arduino.yml
+++ b/.github/workflows/test-wrapper-arduino.yml
@@ -50,7 +50,7 @@ jobs:
       run: ls -d */
     - name: Copy Generated Arduino Files to Arduino Repo
       run: |
-        cp -a ./Adafruit_Wippersnapper_Arduino/ .
+        cp -a ./Adafruit_Wippersnapper_Arduino/. .
         rm -rf ./src/wippersnapper/
         mkdir ./src/wippersnapper/
         cp -a ./arduino_out/. ./src/wippersnapper

--- a/.github/workflows/test-wrapper-arduino.yml
+++ b/.github/workflows/test-wrapper-arduino.yml
@@ -52,12 +52,12 @@ jobs:
       uses: actions/checkout@v2
       with:
         repository: adafruit/Adafruit_Wippersnapper_Arduino
-#        path: arduino-checkout
+        path: arduino-checkout
     - name: Copy Generated Arduino Files to Arduino Repo
       run: |
-        rm -rf /src/wippersnapper/
-        mkdir /src/wippersnapper/
-        cp -a ./arduino_out/. ./src/
+        rm -rf ./arduino-checkout/src/wippersnapper/
+        mkdir ./arduino-checkout/src/wippersnapper/
+        cp -a ./arduino_out/. ./arduino-checkout/src/
     - name: Install extra Arduino libraries
       run: |
         git clone --quiet https://github.com/brentru/Adafruit_MQTT_Library.git /home/runner/Arduino/libraries/Adafruit_MQTT_Library
@@ -65,5 +65,7 @@ jobs:
         git clone --quiet https://github.com/PaulStoffregen/OneWire.git /home/runner/Arduino/libraries/OneWire
     - name: where is everything? 
       run: ls -lR
+    - name: cd
+      run: cd ./arduino-checkout/
     - name: Test Feather ESP32 Build w/new .proto files
       run: python3 ci/build_platform.py feather_esp32_v2

--- a/.github/workflows/test-wrapper-arduino.yml
+++ b/.github/workflows/test-wrapper-arduino.yml
@@ -45,7 +45,7 @@ jobs:
         repository: adafruit/Adafruit_Wippersnapper_Arduino
     - uses: actions/checkout@v2
       with:
-         repository: brentru/ci-arduino
+         repository: adafruit/ci-arduino
          path: ci
     - name: Install CI-Arduino
       run: bash ci/actions_install.sh

--- a/.github/workflows/test-wrapper-arduino.yml
+++ b/.github/workflows/test-wrapper-arduino.yml
@@ -52,7 +52,6 @@ jobs:
       uses: actions/checkout@v2
       with:
         repository: adafruit/Adafruit_Wippersnapper_Arduino
-        token: ${{ secrets.IO_BOT_PAT }}
         path: arduino-checkout
     - name: Install extra Arduino libraries
       run: |

--- a/.github/workflows/test-wrapper-arduino.yml
+++ b/.github/workflows/test-wrapper-arduino.yml
@@ -47,7 +47,9 @@ jobs:
     - name: pwd
       run: pwd
     - name: list all dirs
-      run: ls -d */
+      run: |
+        ls -d */
+        ls -d ./arduino_out/
     - name: Copy Generated Arduino Files to Arduino Repo
       run: |
         cp -a ./Adafruit_Wippersnapper_Arduino/. .

--- a/.github/workflows/test-wrapper-arduino.yml
+++ b/.github/workflows/test-wrapper-arduino.yml
@@ -63,7 +63,7 @@ jobs:
         git clone --quiet https://github.com/brentru/Adafruit_MQTT_Library.git /home/runner/Arduino/libraries/Adafruit_MQTT_Library
         git clone --quiet https://github.com/milesburton/Arduino-Temperature-Control-Library.git /home/runner/Arduino/libraries/Arduino-Temperature-Control-Library
         git clone --quiet https://github.com/PaulStoffregen/OneWire.git /home/runner/Arduino/libraries/OneWire
-#    - name: cd
-#      run: cd ./arduino-checkout/
+    - name: list
+      run: ls
     - name: Test Feather ESP32 Build w/new .proto files
       run: python3 ci/build_platform.py feather_esp32_v2

--- a/.github/workflows/test-wrapper-arduino.yml
+++ b/.github/workflows/test-wrapper-arduino.yml
@@ -24,6 +24,15 @@ jobs:
       run: |
         git config --global user.name adafruitio
         git config --global user.email adafruitio@adafruit.com
+    - name: Generate Arduino files from .proto Files
+      env:
+        PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION: python
+      run: |
+        mkdir ./arduino_out
+        protoc --plugin=protobuf-checkout/nanopb/generator/protoc-gen-nanopb -Iprotobuf-checkout/nanopb/generator/proto --proto_path=./protobuf-checkout/proto ./protobuf-checkout/proto/wippersnapper/*/*/*.proto --nanopb_out=./arduino_out --nanopb_opt=-I./protobuf-checkout/proto --nanopb_opt=-t
+        # Local (non-CI) build command:
+        # protoc --plugin=nanopb/generator/protoc-gen-nanopb -Inanopb/generator/proto --proto_path=./proto ./proto/wippersnapper/*/*/*.proto --nanopb_out=./arduino_out --nanopb_opt=-I./proto --nanopb_opt=-t
+        pwd
     - name: Checkout Arduino Repo
       uses: actions/checkout@v2
       with:
@@ -37,14 +46,6 @@ jobs:
     - name: Install Dependencies
       run: |
         pip3 install esptool
-    - name: Generate Arduino files from .proto Files
-      env:
-        PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION: python
-      run: |
-        mkdir ./arduino_out
-        protoc --plugin=protobuf-checkout/nanopb/generator/protoc-gen-nanopb -Iprotobuf-checkout/nanopb/generator/proto --proto_path=./protobuf-checkout/proto ./protobuf-checkout/proto/wippersnapper/*/*/*.proto --nanopb_out=./arduino_out --nanopb_opt=-I./protobuf-checkout/proto --nanopb_opt=-t
-        # Local (non-CI) build command:
-        # protoc --plugin=nanopb/generator/protoc-gen-nanopb -Inanopb/generator/proto --proto_path=./proto ./proto/wippersnapper/*/*/*.proto --nanopb_out=./arduino_out --nanopb_opt=-I./proto --nanopb_opt=-t
     - name: pwd
       run: pwd
     - name: list all dirs
@@ -54,5 +55,10 @@ jobs:
         rm -rf ./src/wippersnapper/
         mkdir ./src/wippersnapper/
         cp -a ./arduino_out/. ./src/wippersnapper
+    - name: Install extra Arduino libraries
+      run: |
+        git clone --quiet https://github.com/brentru/Adafruit_MQTT_Library.git /home/runner/Arduino/libraries/Adafruit_MQTT_Library
+        git clone --quiet https://github.com/milesburton/Arduino-Temperature-Control-Library.git /home/runner/Arduino/libraries/Arduino-Temperature-Control-Library
+        git clone --quiet https://github.com/PaulStoffregen/OneWire.git /home/runner/Arduino/libraries/OneWire
     - name: Test Feather ESP32 Build w/new .proto files
       run: python3 ci/build_platform.py feather_esp32_v2

--- a/.github/workflows/test-wrapper-arduino.yml
+++ b/.github/workflows/test-wrapper-arduino.yml
@@ -56,7 +56,7 @@ jobs:
         rm -rf ./src/wippersnapper/
         mkdir ./src/wippersnapper/
         cp -a ./arduino_out/. ./src/wippersnapper
-        ls -R ./src/arduino_out/
+        ls -R ./arduino_out/
         ls -R ./src/wippersnapper/
     - name: Install extra Arduino libraries
       run: |

--- a/.github/workflows/test-wrapper-arduino.yml
+++ b/.github/workflows/test-wrapper-arduino.yml
@@ -1,5 +1,5 @@
 name: Generate wrapper files and test Arduino build
-on: [pull]
+on: [ push ]
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-wrapper-arduino.yml
+++ b/.github/workflows/test-wrapper-arduino.yml
@@ -1,0 +1,68 @@
+name: Generate wrapper files and test Arduino build
+on: [pull]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/setup-python@v2
+      with:
+        python-version: '3.x'
+    - name: Install Protoc
+      uses: arduino/setup-protoc@v1
+      with:
+        version: '3.13.0'
+    - name: Install Python dependencies
+      run : |
+        python -m pip install --upgrade pip
+        pip install protobuf
+    - name: Self Checkout
+      uses: actions/checkout@v2
+      with:
+        path: protobuf-checkout
+        submodules: true
+    - name: Configure Git
+      run: |
+        git config --global user.name adafruitio
+        git config --global user.email adafruitio@adafruit.com
+    - name: Generate Python & JS Wrapper Files from .proto Files
+      run: |
+        mkdir ./python_out
+        mkdir ./python_nanopb_out
+        mkdir ./js_out
+        protoc --proto_path=./protobuf-checkout/proto ./protobuf-checkout/proto/wippersnapper/*/*/*.proto --js_out=import_style=commonjs,binary:js_out --python_out=./python_out
+        protoc ./protobuf-checkout/nanopb/generator/proto/nanopb.proto --js_out=import_style=commonjs,binary:js_out --python_out=./python_nanopb_out
+    - name: Generate Arduino files from .proto Files
+      env:
+        PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION: python
+      run: |
+        mkdir ./arduino_out
+        protoc --plugin=protobuf-checkout/nanopb/generator/protoc-gen-nanopb -Iprotobuf-checkout/nanopb/generator/proto --proto_path=./protobuf-checkout/proto ./protobuf-checkout/proto/wippersnapper/*/*/*.proto --nanopb_out=./arduino_out --nanopb_opt=-I./protobuf-checkout/proto --nanopb_opt=-t
+        # Local (non-CI) build command:
+        # protoc --plugin=nanopb/generator/protoc-gen-nanopb -Inanopb/generator/proto --proto_path=./proto ./proto/wippersnapper/*/*/*.proto --nanopb_out=./arduino_out --nanopb_opt=-I./proto --nanopb_opt=-t
+    - uses: actions/checkout@v2
+      with:
+         repository: brentru/ci-arduino
+         path: ci
+    - name: Install CI-Arduino
+      run: bash ci/actions_install.sh
+    - name: Install Dependencies
+      run: |
+        pip3 install esptool
+    - name: Checkout Arduino Repo
+      uses: actions/checkout@v2
+      with:
+        repository: adafruit/Adafruit_Wippersnapper_Arduino
+        token: ${{ secrets.IO_BOT_PAT }}
+        path: arduino-checkout
+    - name: Install extra Arduino libraries
+      run: |
+        git clone --quiet https://github.com/brentru/Adafruit_MQTT_Library.git /home/runner/Arduino/libraries/Adafruit_MQTT_Library
+        git clone --quiet https://github.com/milesburton/Arduino-Temperature-Control-Library.git /home/runner/Arduino/libraries/Arduino-Temperature-Control-Library
+        git clone --quiet https://github.com/PaulStoffregen/OneWire.git /home/runner/Arduino/libraries/OneWire
+    - name: Copy Generated Arduino Files to Arduino Repo
+      run: |
+        rm -rf ./arduino-checkout/src/wippersnapper/
+        mkdir ./arduino-checkout/src/wippersnapper/
+        cp -a ./arduino_out/. ./arduino-checkout/src/
+    - name: build ESP32 platforms
+      run: python3 ci/build_platform.py feather_esp32_v2

--- a/.github/workflows/test-wrapper-arduino.yml
+++ b/.github/workflows/test-wrapper-arduino.yml
@@ -56,7 +56,8 @@ jobs:
         rm -rf ./src/wippersnapper/
         mkdir ./src/wippersnapper/
         cp -a ./arduino_out/. ./src/wippersnapper
-        ls -a ./src/wippersnapper
+        ls -R ./src/arduino_out/
+        ls -R ./src/wippersnapper/
     - name: Install extra Arduino libraries
       run: |
         git clone --quiet https://github.com/brentru/Adafruit_MQTT_Library.git /home/runner/Arduino/libraries/Adafruit_MQTT_Library

--- a/.github/workflows/test-wrapper-arduino.yml
+++ b/.github/workflows/test-wrapper-arduino.yml
@@ -55,7 +55,7 @@ jobs:
         cp -a ./Adafruit_Wippersnapper_Arduino/. .
         rm -rf ./src/wippersnapper/
         mkdir ./src/wippersnapper/
-        cp -a ./arduino_out/. ./src/wippersnapper
+        cp -a ./arduino_out/. ./src/.
         ls -R ./arduino_out/
         ls -R ./src/wippersnapper/
     - name: Install extra Arduino libraries

--- a/.github/workflows/test-wrapper-arduino.yml
+++ b/.github/workflows/test-wrapper-arduino.yml
@@ -1,5 +1,5 @@
 name: Generate new proto wrapper files and test WipperSnapper build
-on: [ push ]
+on: [ pull_request ]
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-wrapper-arduino.yml
+++ b/.github/workflows/test-wrapper-arduino.yml
@@ -24,21 +24,6 @@ jobs:
       run: |
         git config --global user.name adafruitio
         git config --global user.email adafruitio@adafruit.com
-    - name: Generate Python & JS Wrapper Files from .proto Files
-      run: |
-        mkdir ./python_out
-        mkdir ./python_nanopb_out
-        mkdir ./js_out
-        protoc --proto_path=./protobuf-checkout/proto ./protobuf-checkout/proto/wippersnapper/*/*/*.proto --js_out=import_style=commonjs,binary:js_out --python_out=./python_out
-        protoc ./protobuf-checkout/nanopb/generator/proto/nanopb.proto --js_out=import_style=commonjs,binary:js_out --python_out=./python_nanopb_out
-    - name: Generate Arduino files from .proto Files
-      env:
-        PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION: python
-      run: |
-        mkdir ./arduino_out
-        protoc --plugin=protobuf-checkout/nanopb/generator/protoc-gen-nanopb -Iprotobuf-checkout/nanopb/generator/proto --proto_path=./protobuf-checkout/proto ./protobuf-checkout/proto/wippersnapper/*/*/*.proto --nanopb_out=./arduino_out --nanopb_opt=-I./protobuf-checkout/proto --nanopb_opt=-t
-        # Local (non-CI) build command:
-        # protoc --plugin=nanopb/generator/protoc-gen-nanopb -Inanopb/generator/proto --proto_path=./proto ./proto/wippersnapper/*/*/*.proto --nanopb_out=./arduino_out --nanopb_opt=-I./proto --nanopb_opt=-t
     - name: Checkout Arduino Repo
       uses: actions/checkout@v2
       with:
@@ -52,9 +37,22 @@ jobs:
     - name: Install Dependencies
       run: |
         pip3 install esptool
+    - name: Generate Arduino files from .proto Files
+      env:
+        PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION: python
+      run: |
+        mkdir ./arduino_out
+        protoc --plugin=protobuf-checkout/nanopb/generator/protoc-gen-nanopb -Iprotobuf-checkout/nanopb/generator/proto --proto_path=./protobuf-checkout/proto ./protobuf-checkout/proto/wippersnapper/*/*/*.proto --nanopb_out=./arduino_out --nanopb_opt=-I./protobuf-checkout/proto --nanopb_opt=-t
+        # Local (non-CI) build command:
+        # protoc --plugin=nanopb/generator/protoc-gen-nanopb -Inanopb/generator/proto --proto_path=./proto ./proto/wippersnapper/*/*/*.proto --nanopb_out=./arduino_out --nanopb_opt=-I./proto --nanopb_opt=-t
     - name: pwd
       run: pwd
     - name: list all dirs
       run: ls -d */
+    - name: Copy Generated Arduino Files to Arduino Repo
+      run: |
+        rm -rf ./src/wippersnapper/
+        mkdir ./src/wippersnapper/
+        cp -a ./arduino_out/. ./src/wippersnapper
     - name: Test Feather ESP32 Build w/new .proto files
       run: python3 ci/build_platform.py feather_esp32_v2

--- a/.github/workflows/test-wrapper-arduino.yml
+++ b/.github/workflows/test-wrapper-arduino.yml
@@ -36,11 +36,11 @@ jobs:
     - name: Install CI-Arduino
       run: |
         mkdir ./ci/
-        git clone --quiet git@github.com:adafruit/ci-arduino.git ./ci/
+        git clone --quiet https://github.com/adafruit/ci-arduino.git ./ci/
         bash ci/actions_install.sh
     - name: Clone Arduino Repo
       run: |
-        git clone --quiet git@github.com:adafruit/Adafruit_Wippersnapper_Arduino.git
+        git clone --quiet https://github.com/adafruit/Adafruit_Wippersnapper_Arduino.git
     - name: Install Dependencies
       run: |
         pip3 install esptool

--- a/.github/workflows/test-wrapper-arduino.yml
+++ b/.github/workflows/test-wrapper-arduino.yml
@@ -52,19 +52,17 @@ jobs:
       uses: actions/checkout@v2
       with:
         repository: adafruit/Adafruit_Wippersnapper_Arduino
-        path: arduino-checkout
-    - name: Copy Generated Arduino Files to Arduino Repo
-      run: |
-        rm -rf ./arduino-checkout/src/wippersnapper/
-        mkdir ./arduino-checkout/src/wippersnapper/
-        cp -a ./arduino_out/. ./arduino-checkout/src/
+#        path: arduino-checkout
+#    - name: Copy Generated Arduino Files to Arduino Repo
+#      run: |
+#        rm -rf ./arduino-checkout/src/wippersnapper/
+#        mkdir ./arduino-checkout/src/wippersnapper/
+#        cp -a ./arduino_out/. ./arduino-checkout/src/
     - name: Install extra Arduino libraries
       run: |
         git clone --quiet https://github.com/brentru/Adafruit_MQTT_Library.git /home/runner/Arduino/libraries/Adafruit_MQTT_Library
         git clone --quiet https://github.com/milesburton/Arduino-Temperature-Control-Library.git /home/runner/Arduino/libraries/Arduino-Temperature-Control-Library
         git clone --quiet https://github.com/PaulStoffregen/OneWire.git /home/runner/Arduino/libraries/OneWire
-    - name: where is everything? 
-      run: ls -lR
     - name: cd
       run: cd ./arduino-checkout/
     - name: Test Feather ESP32 Build w/new .proto files

--- a/.github/workflows/test-wrapper-arduino.yml
+++ b/.github/workflows/test-wrapper-arduino.yml
@@ -1,4 +1,4 @@
-name: Generate wrapper files and test Arduino build
+name: Generate new proto wrapper files and test WipperSnapper build
 on: [ push ]
 jobs:
   build:
@@ -32,36 +32,25 @@ jobs:
         protoc --plugin=protobuf-checkout/nanopb/generator/protoc-gen-nanopb -Iprotobuf-checkout/nanopb/generator/proto --proto_path=./protobuf-checkout/proto ./protobuf-checkout/proto/wippersnapper/*/*/*.proto --nanopb_out=./arduino_out --nanopb_opt=-I./protobuf-checkout/proto --nanopb_opt=-t
         # Local (non-CI) build command:
         # protoc --plugin=nanopb/generator/protoc-gen-nanopb -Inanopb/generator/proto --proto_path=./proto ./proto/wippersnapper/*/*/*.proto --nanopb_out=./arduino_out --nanopb_opt=-I./proto --nanopb_opt=-t
-        pwd
     - name: Install CI-Arduino
       run: |
         mkdir ./ci/
         git clone --quiet https://github.com/adafruit/ci-arduino.git ./ci/
         bash ci/actions_install.sh
-    - name: Clone Arduino Repo
-      run: |
-        git clone --quiet https://github.com/adafruit/Adafruit_Wippersnapper_Arduino.git
-    - name: Install Dependencies
+    - name: Install ESPTool
       run: |
         pip3 install esptool
-    - name: pwd
-      run: pwd
-    - name: list all dirs
+    - name: Clone WipperSnapper Arduino Repo + Libraries
       run: |
-        ls -d */
-        ls arduino_out/
-    - name: Copy Generated Arduino Files to Arduino Repo
+        git clone --quiet https://github.com/adafruit/Adafruit_Wippersnapper_Arduino.git
+        git clone --quiet https://github.com/brentru/Adafruit_MQTT_Library.git /home/runner/Arduino/libraries/Adafruit_MQTT_Library
+        git clone --quiet https://github.com/milesburton/Arduino-Temperature-Control-Library.git /home/runner/Arduino/libraries/Arduino-Temperature-Control-Library
+        git clone --quiet https://github.com/PaulStoffregen/OneWire.git /home/runner/Arduino/libraries/OneWire
+    - name: Copy Generated Proto Files to Arduino Repo
       run: |
         cp -a ./Adafruit_Wippersnapper_Arduino/. .
         rm -rf ./src/wippersnapper/
         mkdir ./src/wippersnapper/
         cp -a ./arduino_out/. ./src/.
-        ls -R ./arduino_out/
-        ls -R ./src/wippersnapper/
-    - name: Install extra Arduino libraries
-      run: |
-        git clone --quiet https://github.com/brentru/Adafruit_MQTT_Library.git /home/runner/Arduino/libraries/Adafruit_MQTT_Library
-        git clone --quiet https://github.com/milesburton/Arduino-Temperature-Control-Library.git /home/runner/Arduino/libraries/Arduino-Temperature-Control-Library
-        git clone --quiet https://github.com/PaulStoffregen/OneWire.git /home/runner/Arduino/libraries/OneWire
-    - name: Test Feather ESP32 Build w/new .proto files
+    - name: Test building WipperSnapper on ESP32 with new proto files
       run: python3 ci/build_platform.py feather_esp32_v2

--- a/.github/workflows/test-wrapper-arduino.yml
+++ b/.github/workflows/test-wrapper-arduino.yml
@@ -45,6 +45,8 @@ jobs:
          path: ci
     - name: Install CI-Arduino
       run: bash ci/actions_install.sh
+    - name: list ci
+      run: ls ci
     - name: Install Dependencies
       run: |
         pip3 install esptool
@@ -52,7 +54,6 @@ jobs:
       uses: actions/checkout@v2
       with:
         repository: adafruit/Adafruit_Wippersnapper_Arduino
-#        path: arduino-checkout
 #    - name: Copy Generated Arduino Files to Arduino Repo
 #      run: |
 #        rm -rf ./arduino-checkout/src/wippersnapper/

--- a/.github/workflows/test-wrapper-arduino.yml
+++ b/.github/workflows/test-wrapper-arduino.yml
@@ -53,15 +53,17 @@ jobs:
       with:
         repository: adafruit/Adafruit_Wippersnapper_Arduino
         path: arduino-checkout
-    - name: Install extra Arduino libraries
-      run: |
-        git clone --quiet https://github.com/brentru/Adafruit_MQTT_Library.git /home/runner/Arduino/libraries/Adafruit_MQTT_Library
-        git clone --quiet https://github.com/milesburton/Arduino-Temperature-Control-Library.git /home/runner/Arduino/libraries/Arduino-Temperature-Control-Library
-        git clone --quiet https://github.com/PaulStoffregen/OneWire.git /home/runner/Arduino/libraries/OneWire
     - name: Copy Generated Arduino Files to Arduino Repo
       run: |
         rm -rf ./arduino-checkout/src/wippersnapper/
         mkdir ./arduino-checkout/src/wippersnapper/
         cp -a ./arduino_out/. ./arduino-checkout/src/
-    - name: build ESP32 platforms
+    - name: Install extra Arduino libraries
+      run: |
+        git clone --quiet https://github.com/brentru/Adafruit_MQTT_Library.git /home/runner/Arduino/libraries/Adafruit_MQTT_Library
+        git clone --quiet https://github.com/milesburton/Arduino-Temperature-Control-Library.git /home/runner/Arduino/libraries/Arduino-Temperature-Control-Library
+        git clone --quiet https://github.com/PaulStoffregen/OneWire.git /home/runner/Arduino/libraries/OneWire
+    - name: where is everything? 
+      run: ls -lR
+    - name: Test Feather ESP32 Build w/new .proto files
       run: python3 ci/build_platform.py feather_esp32_v2

--- a/proto/wippersnapper/pwm/v1/pwm.proto
+++ b/proto/wippersnapper/pwm/v1/pwm.proto
@@ -11,7 +11,7 @@ import "nanopb/nanopb.proto";
 * On non-ESP32 Arduino, this does nothing.
 */
 message PWMAttachRequest {
-  string fakepin       = 1 [(nanopb).max_size = 6]; /** The pin to be attached. */
+  string pin       = 1 [(nanopb).max_size = 6]; /** The pin to be attached. */
   int32 frequency  = 2; /** PWM frequency of an analog pin, in Hz. **/
   int32 resolution = 3; /** The resolution of an analog pin, in bits. **/
 }

--- a/proto/wippersnapper/pwm/v1/pwm.proto
+++ b/proto/wippersnapper/pwm/v1/pwm.proto
@@ -11,7 +11,7 @@ import "nanopb/nanopb.proto";
 * On non-ESP32 Arduino, this does nothing.
 */
 message PWMAttachRequest {
-  string pin       = 1 [(nanopb).max_size = 6]; /** The pin to be attached. */
+  string fakepin       = 1 [(nanopb).max_size = 6]; /** The pin to be attached. */
   int32 frequency  = 2; /** PWM frequency of an analog pin, in Hz. **/
   int32 resolution = 3; /** The resolution of an analog pin, in bits. **/
 }


### PR DESCRIPTION
This pull request resolves and addresses the second bullet point in https://github.com/adafruit/Wippersnapper_Protobuf/issues/105:
> We may want to try building the WipperSnapper Arduino firmware during [protoc-wrapper-generation.yml](https://github.com/adafruit/Wippersnapper_Protobuf/blob/master/.github/workflows/protoc-wrapper-generation.yml). The firmware would need to be built with the new protocol buffers [produced by this step](https://github.com/adafruit/Wippersnapper_Protobuf/blob/master/.github/workflows/protoc-wrapper-generation.yml#L74).
Currently, we only test that we can build the new protocol buffer files with nanopb, and checkout a PR on WipperSnapper Arduino. We've recently run into cases where the generated files do not compile in the WipperSnapper Arduino repo. This could be solved by requiring this repo's workflow to build the WS arduino firmware for one test hardware case.

tldr; PR adds new workflow, `test-wrapper-arduino.yml` to generate new proto wrapper files for all pull requests. Tests if WipperSnapper still builds.

Working example:
* I remove a field from an existing proto file:
https://github.com/brentru/Wippersnapper_Protobuf/commit/048ce94dcdf440702e170467c29e5cda036600ce

* This PR's new workflow runs, generates the arduino wrapper files, loads them into WS Arduino, builds wippersnapper firmware, and fails on the pin that was changed:
https://github.com/brentru/Wippersnapper_Protobuf/actions/runs/3535053918/jobs/5932638758#step:12:108
