### PR TITLE
Add more color orders for pixels

### DIFF
--- a/proto/wippersnapper/pixels/v1/pixels.proto
+++ b/proto/wippersnapper/pixels/v1/pixels.proto
@@ -26,6 +26,9 @@ enum PixelsOrder {
   PIXELS_ORDER_RGB          = 3; /** Red, Green, Blue */
   PIXELS_ORDER_RGBW         = 4; /** Red, Green, Blue, White */
   PIXELS_ORDER_BRG          = 5; /** DEFAULT for DotStars - Blue, Red, Green */
+  PIXELS_ORDER_RBG          = 6; /** Red, Blue Green */
+  PIXELS_ORDER_GBR          = 7; /** Green, Blue, Red */
+  PIXELS_ORDER_BGR          = 8; /** Blue, Green, Red */
 }
 
 /**


### PR DESCRIPTION
This pull request adds 3 more color orders to the pixel API - RGB, GBR, and BGR.

@lorennorman  - You may want to check the broker code to see if they need to be manually implemented on your end. Otherwise, feel free to approve when OK.