### PR TITLE
Add new type for TVOC

### DIFF
--- a/proto/wippersnapper/i2c/v1/i2c.proto
+++ b/proto/wippersnapper/i2c/v1/i2c.proto
@@ -185,6 +185,7 @@ enum SensorType {
   SENSOR_TYPE_OBJECT_TEMPERATURE_FAHRENHEIT  = 32; /** Temperature of the object a sensor is touching/pointed at, in degrees Fahrenheit, "{value}°F".*/
   SENSOR_TYPE_VOC_INDEX                      = 33; /** Values are an index from 1-500 with 100 being normal, "${$v} VOC".*/
   SENSOR_TYPE_NOX_INDEX                      = 34; /** Values are an index from 1-500 with 100 being normal, "${$v} NOx".*/
+  SENSOR_TYPE_TVOC                           = 35; /** Values are in parts per billion (ppb), "${$v} ppb". */
 }
 
 /**


### PR DESCRIPTION
Adding new type matching TVOC in Adafruit_Sensor:
https://github.com/adafruit/Adafruit_Sensor/blob/master/Adafruit_Sensor.h#L70


Addressing issue within https://github.com/adafruit/Wippersnapper_Components/pull/129
