### PR TITLE
Add documentation for all protobuf messages

### DIFF
--- a/proto/wippersnapper/description/v1/description.md
+++ b/proto/wippersnapper/description/v1/description.md
@@ -1,0 +1,60 @@
+
+# description.proto
+
+This file details how WipperSnapper firmware. registers a new or checks-in an existing board with the Adafruit IO MQTT broker.
+
+
+## Sequence Diagrams
+
+ 
+### Process: Check in
+
+WipperSnapper's check in process involves a board sending its hardware identifier, MAC address and library version to the MQTT Broker. The broker verifies if the hardware's "digital twin" definition exists within the [WipperSnapper_Boards](https://github.com/adafruit/Wippersnapper_Boards) repository. 
+
+Then, the broker sends a message back to the board with `OK` if found within the repo. If the board was not found within the repo,  the `NOT_FOUND` response is sent and the board should disconnect from the broker and halt.
+
+```mermaid
+
+sequenceDiagram
+
+autonumber
+
+Device-->>IO: CreateDescriptionRequest
+Note over Device,IO: This message is sent over the general MQTT <br>topic: /:user/wprsnpr/status
+IO->>Storage (DB): Check if machine_name<br>exists as a JSON definition <br> within the Boards repo
+Storage (DB)->>IO: Return RESPONSE_OK<br>or RESPONSE_BOARD_NOT_FOUND
+IO-->>Device: CreateDescriptionResponse 
+Note over IO,Device: Contains metadata about the physical hardware<br>from the JSON definition file.
+```
+
+
+### Process: Hardware Configuration
+
+Where it can, the WipperSnapper firmware avoids dynamic allocation. If the `CreateDescriptionResponse` message contains a valid response( `RESPONSE_OK` ), fields from the `CreateDescriptionResponse` message are parsed and used to configure some hardware-specific classes:
+  
+```mermaid
+sequenceDiagram
+autonumber
+App->>Application: Parse CreateDescriptionResponse
+App->>Digital IO Class: Configure total_gpio_pins 
+App->>Analog IO Class: Configure total_analog_pins and reference_voltage 
+App->>I2C Class: Configure total_i2c_ports
+```
+
+### Process: Hardware Sync
+
+The hardware sync process described by this API is outdated and will be depreciated in a future API version. It only exists for use with the Digital IO class.  
+
+After the broker sends the `CreateDescriptionResponse` message, it sends the values and states for any digital IO pins configured on the device. Then, it waits for a `RegistrationComplete` response from the device. The `RegistrationComplete` message confirms that the hardware has completed configuring its state and values.
+  
+```mermaid
+sequenceDiagram
+autonumber
+IO-->>Device: CreateDescriptionResponse
+IO-->>Device: ConfigurePinRequests
+Note over IO,Device: This message contains a list of<br>ConfigurePinRequest messages, one per <br>digital GPIO pin.
+Device-->>DigitalGPIO: Decode and configure<br> each ConfigurePinRequest message
+Device-->>IO: RegistrationComplete
+Note over Device,IO: After the ConfigurePinRequests have completed, <br>tell the broker that the device<br> is ready to accept MQTT commands.
+```
+  

--- a/proto/wippersnapper/ds18x20/v1/ds18x20.md
+++ b/proto/wippersnapper/ds18x20/v1/ds18x20.md
@@ -1,0 +1,58 @@
+
+# ds18x20.proto
+
+This file details the API used by hardware running Adafruit WipperSnapper firmware for interfacing with a DS18B20 temperature sensor.
+
+**Note about design and implementation**: WipperSnapper defines a pin as a OneWire bus. Only one DS18x20 sensor is allowed per pin. To use multiple DS18x20 sensors, use multiple pins.
+
+## WipperSnapper Component Definitions
+
+The following JSON component definition type(s) reference `ds18x20.proto`:
+* [ds18x20](https://github.com/adafruit/Wippersnapper_Components/tree/main/components/ds18x20)
+
+## Sequence Diagrams
+
+### Create: DS18x20
+
+Request from a broker to:
+1) Initialize a OneWire bus on a desired pin
+2) Initialize and configure a DS18x20 Maxim temperature sensor on the OneWire bus
+
+```mermaid
+
+sequenceDiagram
+
+autonumber
+
+IO-->>Device: Ds18x20InitRequest
+Device->>IO: Ds18x20InitResponse
+```
+
+### Delete: DS18x20
+
+Request from a broker to:
+1) De-initialize a DS18x20 object's driver
+2) Release the pin from being used as a OneWire bus
+
+```mermaid
+
+sequenceDiagram
+
+autonumber
+
+Device->>IO: Ds18x20DeInitRequest
+```
+
+### Sensor Event: DS18x20
+
+Message containing data and metadata from a DS18x20 sensor.
+
+```mermaid
+
+sequenceDiagram
+
+autonumber
+
+Device->>IO: Ds18x20DeviceEvent
+Note over Device,IO: This message contains i2c.SensorEvent,<br>which contains the sensor's value unit. <br> Since a device may have >1DS18X20 <br>sensor, it also contains the sensor's pin <br>for addressing
+```

--- a/proto/wippersnapper/i2c/v1/i2c.md
+++ b/proto/wippersnapper/i2c/v1/i2c.md
@@ -1,0 +1,95 @@
+
+# i2c.proto
+
+This file details the API used by hardware running Adafruit WipperSnapper firmware for interfacing with the I2C bus and I2C sensors.
+
+## WipperSnapper Component Definitions
+
+The following JSON component definition type(s) reference `i2c.proto`:
+* [i2c](https://github.com/adafruit/Wippersnapper_Components/tree/main/components/i2c)
+
+## Sequence Diagrams
+
+### I2C Scan
+
+On Adafruit.io, an I2C scan can be initialized one of two ways:
+1) User clicks "I2C Scan" button 
+2) Users clicks an I2C component from the Component Picker
+
+**Note:** The I2C scan always contains a I2CBusInitRequest message in case the bus was not previously initialized.
+
+```mermaid
+sequenceDiagram
+autonumber
+
+IO->>Device: I2CBusScanRequest<br>(contains I2CBusInitRequest)
+Device->>App: I2CBusInitRequest
+App->>Device: BusResponse
+Device->>App: i2c_port_number
+App->>I2C Class: Perform scan on<br>i2c_port_number 
+I2C Class->>App: addresses_found
+App->>Device: I2CBusScanResponse
+Device->>IO: I2CBusScanResponse
+```
+
+### Create a new I2C device
+
+**Note:** I2C devices may contain _multiple_ sensors (i.e: one device can contain a temperature and humidity sensor).  To work with multiple sensors, I2C commands typically contain a `I2CDeviceSensorProperties` sub-message, detailing the properties of the I2C device's sensor.
+
+```mermaid
+sequenceDiagram
+autonumber
+
+IO->>Device: I2CDeviceInitRequest<br>(contains I2CBusInitRequest)
+Device->>App: I2CBusInitRequest
+App->>Device: BusResponse
+Device->>App: I2CDeviceInitRequest
+App->>I2C Class: i2c_device_address, i2c_device_name,<br>i2c_device_properties
+Note over App,I2C Class: At this point, the I2C sensor is configured <br>and ready to send data to Adafruit IO.
+I2C Class->>App: I2CDeviceInitResponse
+App->>Device: I2CDeviceInitResponse
+Device->>IO: I2CDeviceInitResponse
+```
+
+### Update an existing I2C device
+
+```mermaid
+sequenceDiagram
+autonumber
+
+IO->>Device: I2CDeviceUpdateRequest
+Device->>App: I2CDeviceUpdateRequest
+App->>I2C Class: I2CDeviceUpdateRequest
+Note over App,I2C Class: Update the properties of the "sub-sensors" <br> specified within i2c_device_properties array.
+I2C Class->>App: I2CDeviceUpdateResponse
+App->>Device: I2CDeviceUpdateResponse
+Device->>IO: I2CDeviceUpdateResponse
+```
+
+### Sending data from an I2C component
+
+The process of sending data from an I2C component involves a device sending a `I2CDeviceEvent` message to the broker. Since an i2c component may have more than one sub-component (i.e: a component may contain both a temperature sensor and a humidity sensor), the `sensor_event` is a repeated submessage array which contains the value and corresponding SI unit for all sub-sensors.
+
+While the sequence diagram for this type of message looks simple, the process involves work on the MQTT broker to unpack and parse each `sensor_event` message:
+
+```mermaid
+sequenceDiagram
+autonumber
+
+Device->>IO: I2CDeviceEvent
+```
+
+
+### Delete an I2C device
+
+The process of deleting an I2C device is straightforward and only requires the device's unique I2C address:
+
+```mermaid
+sequenceDiagram
+autonumber
+
+IO->>Device: I2CDeviceDeinitRequest
+Device->>IO: I2CDeviceDeinitResponse
+```
+
+

--- a/proto/wippersnapper/signal/v1/signal.md
+++ b/proto/wippersnapper/signal/v1/signal.md
@@ -1,0 +1,20 @@
+
+# signal.proto
+
+This file details the `signal.proto` message used to communicate between WipperSnapper clients. The signal file contains high-level `oneof` messages that "wrap" the following protocol buffer APIs: `pin.proto`, `i2c.proto`, `servo.proto`, `pwm.proto`, `ds18x20.proto`, `pixels .proto`, `uart.proto`.
+
+## Sequence Diagrams
+
+### Generalized `msgRequest` and `msgResponse`
+
+Within `signal.proto`, each `.proto` API contains both a `request` and `response` message. The `request` message is a command sent from the broker to a device. The `response` message is a command sent from the device to the broker.
+
+```mermaid
+sequenceDiagram
+autonumber
+
+IO->>Device: msgRequest
+Note over IO,Device: Device unpacks`payload` message.
+Device->>IO: msgResponse
+Note over Device,IO: Broker unpacks `payload` message
+```


### PR DESCRIPTION
Currently, only `pwm.proto`, `pixels.proto`, `servo.proto`, and `uart.proto` are documented in `.md` format. This pull request documents the remaining protocol buffer messages in this repository: `description.proto`, `ds18x20.proto`, `i2c.proto`, and `signal.proto`

@lorennorman  The intention of doing this is to fully document `master`, tag and release `v1` documentation, and then allow these `.md` files to be modified for changes within https://github.com/adafruit/Wippersnapper_Protobuf/pull/133