### PR TITLE
Add Display Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -138,3 +138,5 @@ dmypy.json
 
 # Cython debug symbols
 cython_debug/
+
+.DS_Store

--- a/proto/wippersnapper/display/v1/display.md
+++ b/proto/wippersnapper/display/v1/display.md
@@ -1,0 +1,75 @@
+
+# display.proto
+
+This file details the WipperSnapper messaging API for interfacing with a display.
+
+## WipperSnapper Components
+
+The following WipperSnapper Components may utilize `display.proto`:
+
+* E-Ink/E-Paper Displays
+* TFT Displays
+* OLED Displays
+* 7-Segment Displays
+* Alphanumeric Displays
+* LCD Character Displays
+
+## Sequence Diagrams
+
+### Attaching a Display Component to a device running WipperSnapper
+
+```mermaid
+sequenceDiagram
+autonumber
+
+IO-->>Device: DisplayAddOrReplace
+Note over IO, Device: DisplayType field dictates which<br>display we are using (LED, E-Ink, etc)
+
+Device->>ws_display controller: DisplayAddOrReplace
+
+ws_display controller->>ws_display hardware: DisplayAddOrReplace
+
+ws_display hardware->>ws_display driver: Driver Configure Request
+
+ws_display driver->>ws_display hardware:  Driver Configure Response
+
+ws_display hardware->>ws_display controller: Hardware Response
+
+ws_display controller-->>Device: DisplayAddedorReplaced
+
+Device-->>IO: DisplayAddedorReplaced
+```
+
+### Removing a Display Component from a device running WipperSnapper
+
+```mermaid
+sequenceDiagram
+autonumber
+
+IO-->>Device: DisplayRemove
+Note over IO, Device: name field dictates which<br>display we are removing
+
+Device->>ws_display controller: DisplayRemove
+
+ws_display controller->>ws_display hardware: Delete hardware instance
+
+ws_display hardware->>ws_display driver: Delete driver instance
+```
+
+### Writing to a Display from IO
+
+The display message is set by the component's feed value, which is a string. The message is sent to the display driver.
+
+```mermaid
+sequenceDiagram
+autonumber
+
+IO-->>Device: DisplayWrite
+Note over IO, Device: name field dictates which<br>display we are writing to
+
+Device->>ws_display controller: handleDisplayWrite()
+
+ws_display controller->>ws_display hardware: Get display hardware
+
+ws_display hardware->>ws_display driver: Execute writeX()
+```

--- a/proto/wippersnapper/display/v1/display.md
+++ b/proto/wippersnapper/display/v1/display.md
@@ -54,6 +54,14 @@ Device->>ws_display controller: DisplayRemove
 ws_display controller->>ws_display hardware: Delete hardware instance
 
 ws_display hardware->>ws_display driver: Delete driver instance
+
+ws_display driver->>ws_display hardware: Deletion Result
+
+ws_display hardware->>ws_display controller: Deletion Result
+
+ws_display controller-->>Device: DisplayRemoved
+
+Device-->>IO: DisplayRemoved
 ```
 
 ### Writing to a Display from IO

--- a/proto/wippersnapper/display/v1/display.proto
+++ b/proto/wippersnapper/display/v1/display.proto
@@ -6,7 +6,6 @@ syntax = "proto3";
 
 package wippersnapper.display.v1;
 import "nanopb/nanopb.proto";
-import "wippersnapper/i2c/v1/i2c.proto";
 
 // ============================================================================
 // Enums
@@ -142,3 +141,4 @@ message DisplayRemoved {
   string name     = 1[(nanopb).max_size = 64]; /** Identifies the display. */
   bool did_remove = 2; /** Indicates if a display was removed */
 }
+

--- a/proto/wippersnapper/display/v1/display.proto
+++ b/proto/wippersnapper/display/v1/display.proto
@@ -51,8 +51,8 @@ enum EPDColors {
  */
 enum EPDThinkInkPanel {
   EPD_THINK_INK_PANEL_UNSPECIFIED = 0; /** Unspecified ThinkInk panel type */
-  EPD_THINK_INK_PANEL_213_GRAYSCALE4_MFGN = 1;
-  EPD_THINK_INK_PANEL_213_GRAYSCALE4_T5 = 2;
+  EPD_THINK_INK_PANEL_290_GRAYSCALE4_MFGN = 1;
+  EPD_THINK_INK_PANEL_290_GRAYSCALE4_T5 = 2;
 }
 
 // ============================================================================

--- a/proto/wippersnapper/display/v1/display.proto
+++ b/proto/wippersnapper/display/v1/display.proto
@@ -68,9 +68,7 @@ message EpdSpiConfig {
  * It includes the mode, dimensions, and panel type.
  */
 message EPDConfig {
-  EPDMode mode           = 1; /** The mode of the EPD display */
-  int32 width            = 2; /** Width of the EPD display, in pixels */
-  int32 height           = 3; /** Height of the EPD display, in pixels */
+  EPDMode mode = 1; /** The mode of the EPD display */
 }
 
 /**
@@ -125,12 +123,14 @@ message DisplayWrite {
  * DisplayAddedorReplaced confirms a display was added or replaced.
  */
 message DisplayAddedorReplaced {
-  bool did_add = 1; /** Indicates if a display was added */
+  string name  = 1[(nanopb).max_size = 64]; /** Identifier for the display. */
+  bool did_add = 2; /** Indicates if a display was added */
 }
 
 /**
  * DisplayRemoved confirms a display was removed.
  */
 message DisplayRemoved {
-  bool did_remove = 1; /** Indicates if a display was removed */
+  string name     = 1[(nanopb).max_size = 64]; /** Identifies the display. */
+  bool did_remove = 2; /** Indicates if a display was removed */
 }

--- a/proto/wippersnapper/display/v1/display.proto
+++ b/proto/wippersnapper/display/v1/display.proto
@@ -59,21 +59,14 @@ message EpdSpiConfig {
 }
 
 /**
- * EPDWriteOptions contains options for writing to EPD displays.
- */
-message EPDWriteOptions { 
-  int32 text_size = 1; /** Scale factor for text (1 = 6x8px, 2 = 12x16px,...) */
-}
-
-/**
  * EPDConfig contains the configuration for an EPD display.
  * It includes the mode, dimensions, and panel type.
  */
 message EPDConfig {
-  EPDMode mode            = 1; /** The mode of the EPD display */
-  EPDWriteOptions options = 2; /** Options for writing to the EPD */
-  int32 width             = 3;   /** Width of the EPD display, in pixels */
-  int32 height            = 4;   /** Height of the EPD display, in pixels */
+  EPDMode mode    = 1; /** The mode of the EPD display */
+  int32 width     = 2;   /** Width of the EPD display, in pixels */
+  int32 height    = 3;   /** Height of the EPD display, in pixels */
+  int32 text_size = 4; /** Scale factor for text (1 = 6x8px, 2 = 12x16px,...) */
 }
 
 /**
@@ -91,9 +84,10 @@ message TftSpiConfig {
 }
 
 message TftConfig {
-  int32 width  = 1;   /** Width of the TFT display in pixels */
-  int32 height = 2;   /** Height of the TFT display in pixels */
-  int32 rotation = 3; /** Rotation of the display (0-3) */
+  int32 width     = 1;   /** Width of the TFT display in pixels */
+  int32 height    = 2;   /** Height of the TFT display in pixels */
+  int32 rotation  = 3; /** Rotation of the display (0-3) */
+  int32 text_size = 4; /** Scale factor for text (1 = 6x8px, 2 = 12x16px,...) */
 }
 
 // ============================================================================

--- a/proto/wippersnapper/display/v1/display.proto
+++ b/proto/wippersnapper/display/v1/display.proto
@@ -74,15 +74,13 @@ message EpdSpiConfig {
 
 /**
  * EPDConfig contains the configuration for an EPD display.
- * It includes the mode, dimensions, and optional pin assignments.
+ * It includes the mode, dimensions, and panel type.
  */
 message EPDConfig {
   EPDMode mode           = 1; /** The mode of the EPD display */
   EPDThinkInkPanel panel = 2; /** Specific ThinkInk panel type */
   int32 width            = 3; /** Width of the EPD display, in pixels */
   int32 height           = 4; /** Height of the EPD display, in pixels */
-  string pin_busy        = 5[(nanopb).max_size = 6]; /** Pin for busy signal */
-  string pin_reset       = 6[(nanopb).max_size = 6]; /** Pin for reset */
 }
 
 /**

--- a/proto/wippersnapper/display/v1/display.proto
+++ b/proto/wippersnapper/display/v1/display.proto
@@ -33,21 +33,43 @@ enum EPDMode {
   EPD_MODE_MONO        = 2; /** Monochrome EPD mode */
 }
 
+/**
+* Desired SSD1306 text 'magnification' size.
+*/
+enum SSD1306TextSize {
+  SSD1306_TEXT_SIZE_UNSPECIFIED = 0; /** Unspecified text size. **/
+  SSD1306_TEXT_SIZE_1           = 1; /** Default text size, 6x8px. **/
+  SSD1306_TEXT_SIZE_2           = 2; /** Larger text size option, 12x16px. **/
+}
+
+/**
+* LEDBackpackAlignment represents all text alignment
+* options for LED backpack displays
+*/
+enum LEDBackpackAlignment {
+  LED_BACKPACK_ALIGNMENT_UNSPECIFIED = 0; /** Unspecified alignment option. **/
+  LED_BACKPACK_ALIGNMENT_LEFT        = 1; /** (Default) Left-aligned. **/
+  LED_BACKPACK_ALIGNMENT_RIGHT       = 2; /** Right-aligned. **/
+}
+
 // ============================================================================
 // Configuration Messages
 // ============================================================================
 
 /**
- * EpdSpiConfig contains the configuration for SPI-based EPD displays.
+ * SpiConfig contains the configuration for SPI-based displays.
  * Includes the SPI bus number and pin assignments.
  */
-message EpdSpiConfig {
+message SpiConfig {
   int32 bus          = 1; /** The SPI bus to use */
   string pin_dc      = 2[(nanopb).max_size = 6]; /** Pin for data/command */
   string pin_rst     = 3[(nanopb).max_size = 6]; /** Pin for reset */
   string pin_cs      = 4[(nanopb).max_size = 6]; /** Pin for chip select */
   string pin_sram_cs = 5[(nanopb).max_size = 6]; /** Pin for SRAM chip select */
   string pin_busy    = 6[(nanopb).max_size = 6]; /** Pin for busy signal */
+  string pin_mosi    = 7[(nanopb).max_size = 6]; /** Pin for MOSI */
+  string pin_sck     = 8[(nanopb).max_size = 6]; /** Pin for SCK */
+  string pin_miso    = 9[(nanopb).max_size = 6]; /** Pin for MISO */
 }
 
 /**
@@ -65,24 +87,39 @@ message EPDWriteOptions {
   int32 text_size = 1; /** Scale factor for text (1 = 6x8px, 2 = 12x16px,...) */
 }
 
-/**
- * TftSpiConfig contains the configuration for SPI TFT displays.
- * Includes the SPI bus number and pin assignments.
- */
-message TftSpiConfig {
-  int32 bus          = 1; /** The SPI bus to use */
-  string pin_cs      = 2[(nanopb).max_size = 6]; /** Pin for chip select */
-  string pin_dc      = 3[(nanopb).max_size = 6]; /** Pin for data/command */
-  string pin_mosi    = 4[(nanopb).max_size = 6]; /** Pin for MOSI */
-  string pin_sck     = 5[(nanopb).max_size = 6]; /** Pin for SCK */
-  string pin_rst     = 6[(nanopb).max_size = 6]; /** Pin for reset */
-  string pin_miso    = 7[(nanopb).max_size = 6]; /** Pin for MISO */
-}
-
 message TftConfig {
   int32 width  = 1;   /** Width of the TFT display in pixels */
   int32 height = 2;   /** Height of the TFT display in pixels */
   int32 rotation = 3; /** Rotation of the display (0-3) */
+}
+
+message I2cConfig {
+  wippersnapper.i2c.v1.I2CDeviceInitRequest i2c = 1; /** I2C configuration */
+}
+
+/**
+* SSD1306Config represents the configuration for a SSD1306 OLED display.
+*/
+message SSD1306Config {
+  uint32 width              = 1; /** Width of the display. **/
+  uint32 height             = 2; /** Height of the display. **/
+  SSD1306TextSize text_size = 3; /** Desired text 'magnification' size. **/
+}
+
+/**
+* LEDBackpackConfig represents the configuration for a LED backpack display.
+*/
+message LEDBackpackConfig {
+  int32 brightness                = 1; /** Desired brightness of the LED backpack, from 0 (off) to 15 (full brightness). **/
+  LEDBackpackAlignment alignment  = 2; /** Desired text alignment for the LED backpack. **/
+}
+
+/**
+* CharLCDConfig represents the configuration for a character LCD display.
+*/
+message CharLCDConfig {
+  uint32 rows            = 1; /** Number of rows for the character LCD. **/
+  uint32 columns         = 2; /** Number of columns for the character LCD. **/
 }
 
 // ============================================================================
@@ -96,12 +133,15 @@ message DisplayAddOrReplace {
   DisplayType type = 1; /** The type of display */
   string name = 2[(nanopb).max_size = 64]; /** Identifier for the display */
   oneof interface_type {
-    EpdSpiConfig spi_epd = 3; /** SPI configuration for EPD */
-    TftSpiConfig spi_tft = 4; /** SPI configuration for TFT */
+    SpiConfig cfg_spi = 3; /** SPI config for EPD */
+    I2cConfig cfg_i2c = 4; /** I2C device config */
   }
   oneof config {
-    EPDConfig config_epd = 5; /** Configuration for EPD display */
-    TftConfig config_tft = 6; /** Configuration for TFT display */
+    EPDConfig config_epd = 5; /** Config for EPD display */
+    TftConfig config_tft = 6; /** Config for TFT display */
+    SSD1306Config config_ssd1306 = 7; /** Config for SSD1306 OLED */
+    LEDBackpackConfig config_led_backpack = 8; /** Config for LED backpack. */
+    CharLCDConfig config_char_lcd = 9; /** Config for character LCD. */
   }
 }
 

--- a/proto/wippersnapper/display/v1/display.proto
+++ b/proto/wippersnapper/display/v1/display.proto
@@ -5,8 +5,8 @@
 syntax = "proto3";
 
 package wippersnapper.display.v1;
-import "nanopb/nanopb.proto";
-import "wippersnapper/i2c/v1/i2c.proto";
+//import "nanopb/nanopb.proto";
+import "i2c.proto";
 
 // ============================================================================
 // Enums
@@ -46,6 +46,15 @@ enum EPDColors {
   EPD_COLORS_YELLOW      = 7; /** Yellow color for EPD */
 }
 
+/**
+ * EPDThinkInkPanel defines specific ThinkInk panel types.
+ */
+enum EPDThinkInkPanel {
+  EPD_THINK_INK_PANEL_UNSPECIFIED = 0; /** Unspecified ThinkInk panel type */
+  EPD_THINK_INK_PANEL_213_GRAYSCALE4_MFGN = 1;
+  EPD_THINK_INK_PANEL_213_GRAYSCALE4_T5 = 2;
+}
+
 // ============================================================================
 // Configuration Messages
 // ============================================================================
@@ -68,11 +77,12 @@ message EpdSpiConfig {
  * It includes the mode, dimensions, and optional pin assignments.
  */
 message EPDConfig {
-  EPDMode mode     = 1; /** The mode of the EPD display */
-  int32 width      = 2; /** Width of the EPD display, in pixels */
-  int32 height     = 3; /** Height of the EPD display, in pixels */
-  string pin_busy  = 4[(nanopb).max_size = 6]; /** Pin for busy signal */
-  string pin_reset = 5[(nanopb).max_size = 6]; /** Pin for reset */
+  EPDMode mode           = 1; /** The mode of the EPD display */
+  EPDThinkInkPanel panel = 2; /** Specific ThinkInk panel type */
+  int32 width            = 3; /** Width of the EPD display, in pixels */
+  int32 height           = 4; /** Height of the EPD display, in pixels */
+  string pin_busy        = 5[(nanopb).max_size = 6]; /** Pin for busy signal */
+  string pin_reset       = 6[(nanopb).max_size = 6]; /** Pin for reset */
 }
 
 /**
@@ -92,10 +102,13 @@ message EPDWriteOptions {
  */
 message DisplayAddOrReplace {
   DisplayType type = 1; /** The type of display */
+  string name = 2[(nanopb).max_size = 64]; /** Identifier for the display */
   oneof interface_type {
-    EpdSpiConfig spi_epd = 2; /** SPI configuration for EPD */
+    EpdSpiConfig spi_epd = 3; /** SPI configuration for EPD */
   }
-  string name = 3[(nanopb).max_size = 6]; /** Identifier for the display */
+  oneof config {
+    EPDConfig epd_config = 4; /** Configuration for EPD display */
+  }
 }
 
 /**

--- a/proto/wippersnapper/display/v1/display.proto
+++ b/proto/wippersnapper/display/v1/display.proto
@@ -32,20 +32,6 @@ enum EPDMode {
   EPD_MODE_MONO        = 2; /** Monochrome EPD mode */
 }
 
-/**
- * EPDColors defines the available colors for EPD displays.
- */
-enum EPDColors {
-  EPD_COLORS_UNSPECIFIED = 0; /** Unspecified color (for consistency) */
-  EPD_COLORS_WHITE       = 1; /** White color for EPD */
-  EPD_COLORS_BLACK       = 2; /** Black color for EPD */
-  EPD_COLORS_RED         = 3; /** Red color for EPD */
-  EPD_COLORS_GRAY        = 4; /** Gray color for EPD */
-  EPD_COLORS_DARK        = 5; /** Dark color for EPD */
-  EPD_COLORS_LIGHT       = 6; /** Light color for EPD */
-  EPD_COLORS_YELLOW      = 7; /** Yellow color for EPD */
-}
-
 // ============================================================================
 // Configuration Messages
 // ============================================================================
@@ -76,7 +62,6 @@ message EPDConfig {
  */
 message EPDWriteOptions { 
   int32 text_size = 1; /** Size of the text to write */
-  EPDColors color = 2; /** Color to use for writing */
 }
 
 // ============================================================================

--- a/proto/wippersnapper/display/v1/display.proto
+++ b/proto/wippersnapper/display/v1/display.proto
@@ -33,6 +33,25 @@ enum EPDMode {
   EPD_MODE_MONO        = 2; /** Monochrome EPD mode */
 }
 
+/**
+* Desired SSD1306 text 'magnification' size.
+*/
+enum SSD1306TextSize {
+  SSD1306_TEXT_SIZE_UNSPECIFIED = 0; /** Unspecified text size. **/
+  SSD1306_TEXT_SIZE_1           = 1; /** Default text size, 6x8px. **/
+  SSD1306_TEXT_SIZE_2           = 2; /** Larger text size option, 12x16px. **/
+}
+
+/**
+* LEDBackpackAlignment represents all text alignment
+* options for LED backpack displays
+*/
+enum LEDBackpackAlignment {
+  LED_BACKPACK_ALIGNMENT_UNSPECIFIED = 0; /** Unspecified alignment option. **/
+  LED_BACKPACK_ALIGNMENT_LEFT        = 1; /** (Default) Left-aligned. **/
+  LED_BACKPACK_ALIGNMENT_RIGHT       = 2; /** Right-aligned. **/
+}
+
 // ============================================================================
 // Configuration Messages
 // ============================================================================
@@ -79,20 +98,20 @@ message I2cConfig {
 }
 
 /**
-* OledConfig represents the configuration for an OLED display.
+* SSD1306Config represents the configuration for a SSD1306 OLED display.
 */
-message OledConfig {
-  uint32 width    = 1; /** Width of the display. **/
-  uint32 height   = 2; /** Height of the display. **/
-  int32 text_size = 3; /** Desired text 'magnification' size. **/
+message SSD1306Config {
+  uint32 width              = 1; /** Width of the display. **/
+  uint32 height             = 2; /** Height of the display. **/
+  SSD1306TextSize text_size = 3; /** Desired text 'magnification' size. **/
 }
 
 /**
 * LEDBackpackConfig represents the configuration for a LED backpack display.
 */
 message LEDBackpackConfig {
-  int32 brightness = 1; /** Desired brightness, from off to full brightness. **/
-  uint32 alignment = 2; /** Desired text alignment for the LED backpack. **/
+  int32 brightness                = 1; /** Desired brightness of the LED backpack, from 0 (off) to 15 (full brightness). **/
+  LEDBackpackAlignment alignment  = 2; /** Desired text alignment for the LED backpack. **/
 }
 
 /**
@@ -120,7 +139,7 @@ message DisplayAddOrReplace {
   oneof config {
     EPDConfig config_epd = 5; /** Config for EPD display */
     TftConfig config_tft = 6; /** Config for TFT display */
-    OledConfig config_oled = 7; /** Config for SSD1306 OLED */
+    SSD1306Config config_ssd1306 = 7; /** Config for SSD1306 OLED */
     LEDBackpackConfig config_led_backpack = 8; /** Config for LED backpack. */
     CharLCDConfig config_char_lcd = 9; /** Config for character LCD. */
   }

--- a/proto/wippersnapper/display/v1/display.proto
+++ b/proto/wippersnapper/display/v1/display.proto
@@ -61,7 +61,7 @@ message EPDConfig {
  * EPDWriteOptions contains options for writing to EPD displays.
  */
 message EPDWriteOptions { 
-  int32 text_size = 1; /** Size of the text to write */
+  int32 text_size = 1; /** Scale factor for text (1 = 6x8px, 2 = 12x16px,...) */
 }
 
 // ============================================================================

--- a/proto/wippersnapper/display/v1/display.proto
+++ b/proto/wippersnapper/display/v1/display.proto
@@ -46,15 +46,6 @@ enum EPDColors {
   EPD_COLORS_YELLOW      = 7; /** Yellow color for EPD */
 }
 
-/**
- * EPDThinkInkPanel defines specific ThinkInk panel types.
- */
-enum EPDThinkInkPanel {
-  EPD_THINK_INK_PANEL_UNSPECIFIED = 0; /** Unspecified ThinkInk panel type */
-  EPD_THINK_INK_PANEL_290_GRAYSCALE4_MFGN = 1;
-  EPD_THINK_INK_PANEL_290_GRAYSCALE4_T5 = 2;
-}
-
 // ============================================================================
 // Configuration Messages
 // ============================================================================
@@ -78,9 +69,8 @@ message EpdSpiConfig {
  */
 message EPDConfig {
   EPDMode mode           = 1; /** The mode of the EPD display */
-  EPDThinkInkPanel panel = 2; /** Specific ThinkInk panel type */
-  int32 width            = 3; /** Width of the EPD display, in pixels */
-  int32 height           = 4; /** Height of the EPD display, in pixels */
+  int32 width            = 2; /** Width of the EPD display, in pixels */
+  int32 height           = 3; /** Height of the EPD display, in pixels */
 }
 
 /**

--- a/proto/wippersnapper/display/v1/display.proto
+++ b/proto/wippersnapper/display/v1/display.proto
@@ -17,9 +17,8 @@ import "nanopb/nanopb.proto";
  */
 enum DisplayType {
   DISPLAY_TYPE_UNSPECIFIED = 0; /** Unspecified display type. */
-  DISPLAY_TYPE_OLED        = 1; /** OLED display type */
-  DISPLAY_TYPE_EPD         = 2; /** EPD display type */
-  DISPLAY_TYPE_TFT         = 3; /** TFT display type */
+  DISPLAY_TYPE_EPD         = 1; /** EPD display type */
+  DISPLAY_TYPE_TFT         = 2; /** TFT display type */
 }
 
 /**
@@ -30,6 +29,16 @@ enum EPDMode {
   EPD_MODE_UNSPECIFIED = 0; /** Unspecified EPD mode */
   EPD_MODE_GRAYSCALE4  = 1; /** Grayscale 4 EPD mode */
   EPD_MODE_MONO        = 2; /** Monochrome EPD mode */
+}
+
+/**
+ * DisplayDriver determines the specific driver to use for the display.
+ */
+enum DisplayDriver {
+  DISPLAY_DRIVER_UNSPECIFIED = 0; /** Unspecified display driver */
+  DISPLAY_DRIVER_EPD_SSD1680 = 1; /** EPD SSD1680 driver */
+  DISPLAY_DRIVER_EPD_ILI0373 = 2; /** EPD SSD167 driver */
+  DISPLAY_DRIVER_TFT_ST7789  = 3; /** TFT ST7789 driver */
 }
 
 // ============================================================================
@@ -50,18 +59,19 @@ message EpdSpiConfig {
 }
 
 /**
+ * EPDWriteOptions contains options for writing to EPD displays.
+ */
+message EPDWriteOptions { 
+  int32 text_size = 1; /** Scale factor for text (1 = 6x8px, 2 = 12x16px,...) */
+}
+
+/**
  * EPDConfig contains the configuration for an EPD display.
  * It includes the mode, dimensions, and panel type.
  */
 message EPDConfig {
   EPDMode mode = 1; /** The mode of the EPD display */
-}
-
-/**
- * EPDWriteOptions contains options for writing to EPD displays.
- */
-message EPDWriteOptions { 
-  int32 text_size = 1; /** Scale factor for text (1 = 6x8px, 2 = 12x16px,...) */
+  EPDWriteOptions options = 2; /** Options for writing to the EPD */
 }
 
 /**
@@ -92,15 +102,15 @@ message TftConfig {
  * DisplayAddOrReplace adds a new display or replaces an existing one.
  */
 message DisplayAddOrReplace {
-  DisplayType type = 1; /** The type of display */
-  string name = 2[(nanopb).max_size = 64]; /** Identifier for the display */
+  DisplayType type       = 1; /** The type of display */
+  DisplayDriver driver   = 2; /** The specific driver for the display */
   oneof interface_type {
-    EpdSpiConfig spi_epd = 3; /** SPI configuration for EPD */
-    TftSpiConfig spi_tft = 4; /** SPI configuration for TFT */
+    EpdSpiConfig spi_epd = 3; /** SPI configuration for EPD. */
+    TftSpiConfig spi_tft = 4; /** SPI configuration for TFT. */
   }
   oneof config {
-    EPDConfig config_epd = 5; /** Configuration for EPD display */
-    TftConfig config_tft = 6; /** Configuration for TFT display */
+    EPDConfig config_epd = 5; /** Configuration for EPD. */
+    TftConfig config_tft = 6; /** Configuration for TFT. */
   }
 }
 
@@ -117,9 +127,6 @@ message DisplayRemove {
 message DisplayWrite {
   string name     = 1[(nanopb).max_size = 64]; /** Identifies the display. */
   string message  = 2[(nanopb).max_size = 1024]; /** Message to write. */
-  oneof options {
-    EPDWriteOptions epd_options = 3; /** Options for writing to EPD displays */
-  }
 }
 
 // ============================================================================

--- a/proto/wippersnapper/display/v1/display.proto
+++ b/proto/wippersnapper/display/v1/display.proto
@@ -103,15 +103,15 @@ message DisplayAddOrReplace {
  * DisplayRemove removes an existing display.
  */
 message DisplayRemove {
-  string name = 1[(nanopb).max_size = 6]; /** Identifier for the display. */
+  string name = 1[(nanopb).max_size = 64]; /** Identifier for the display. */
 }
 
 /**
  * DisplayWrite writes content to a display.
  */
 message DisplayWrite {
-  string name     = 1[(nanopb).max_size = 6]; /** Identifier for the display. */
-  string message  = 2[(nanopb).max_size = 6]; /** Message to write. */
+  string name     = 1[(nanopb).max_size = 64]; /** Identifies the display. */
+  string message  = 2[(nanopb).max_size = 1024]; /** Message to write. */
   oneof options {
     EPDWriteOptions epd_options = 3; /** Options for writing to EPD displays */
   }

--- a/proto/wippersnapper/display/v1/display.proto
+++ b/proto/wippersnapper/display/v1/display.proto
@@ -1,0 +1,135 @@
+// SPDX-FileCopyrightText: 2025 Brent Rubell for Adafruit Industries
+// SPDX-License-Identifier: MIT
+// Display API for Adafruit WipperSnapper
+
+syntax = "proto3";
+
+package wippersnapper.display.v1;
+import "nanopb/nanopb.proto";
+import "wippersnapper/i2c/v1/i2c.proto";
+
+// ============================================================================
+// Enums
+// ============================================================================
+
+/**
+ * DisplayType determines the type of display
+ * and selects which driver should be used.
+ */
+enum DisplayType {
+  DISPLAY_TYPE_UNSPECIFIED = 0; /** Unspecified display type. */
+  DISPLAY_TYPE_OLED        = 1; /** OLED display type */
+  DISPLAY_TYPE_EPD         = 2; /** EPD display type */
+}
+
+/**
+ * EPDMode defines the mode of the EPD display.
+ * This affects how the display renders images.
+ */
+enum EPDMode {
+  EPD_MODE_UNSPECIFIED = 0; /** Unspecified EPD mode */
+  EPD_MODE_GRAYSCALE4  = 1; /** Grayscale 4 EPD mode */
+  EPD_MODE_MONO        = 2; /** Monochrome EPD mode */
+}
+
+/**
+ * EPDColors defines the available colors for EPD displays.
+ */
+enum EPDColors {
+  EPD_COLORS_UNSPECIFIED = 0; /** Unspecified color (for consistency) */
+  EPD_COLORS_WHITE       = 1; /** White color for EPD */
+  EPD_COLORS_BLACK       = 2; /** Black color for EPD */
+  EPD_COLORS_RED         = 3; /** Red color for EPD */
+  EPD_COLORS_GRAY        = 4; /** Gray color for EPD */
+  EPD_COLORS_DARK        = 5; /** Dark color for EPD */
+  EPD_COLORS_LIGHT       = 6; /** Light color for EPD */
+  EPD_COLORS_YELLOW      = 7; /** Yellow color for EPD */
+}
+
+// ============================================================================
+// Configuration Messages
+// ============================================================================
+
+/**
+ * EpdSpiConfig contains the configuration for SPI-based EPD displays.
+ * Includes the SPI bus number and pin assignments.
+ */
+message EpdSpiConfig {
+  int32 bus          = 1; /** The SPI bus to use */
+  string pin_dc      = 2[(nanopb).max_size = 6]; /** Pin for data/command */
+  string pin_rst     = 3[(nanopb).max_size = 6]; /** Pin for reset */
+  string pin_cs      = 4[(nanopb).max_size = 6]; /** Pin for chip select */
+  string pin_sram_cs = 5[(nanopb).max_size = 6]; /** Pin for SRAM chip select */
+  string pin_busy    = 6[(nanopb).max_size = 6]; /** Pin for busy signal */
+}
+
+/**
+ * EPDConfig contains the configuration for an EPD display.
+ * It includes the mode, dimensions, and optional pin assignments.
+ */
+message EPDConfig {
+  EPDMode mode     = 1; /** The mode of the EPD display */
+  int32 width      = 2; /** Width of the EPD display, in pixels */
+  int32 height     = 3; /** Height of the EPD display, in pixels */
+  string pin_busy  = 4[(nanopb).max_size = 6]; /** Pin for busy signal */
+  string pin_reset = 5[(nanopb).max_size = 6]; /** Pin for reset */
+}
+
+/**
+ * EPDWriteOptions contains options for writing to EPD displays.
+ */
+message EPDWriteOptions { 
+  int32 text_size = 1; /** Size of the text to write */
+  EPDColors color = 2; /** Color to use for writing */
+}
+
+// ============================================================================
+// Request Messages
+// ============================================================================
+
+/**
+ * DisplayAddOrReplace adds a new display or replaces an existing one.
+ */
+message DisplayAddOrReplace {
+  DisplayType type = 1; /** The type of display */
+  oneof interface_type {
+    EpdSpiConfig spi_epd = 2; /** SPI configuration for EPD */
+  }
+  string name = 3[(nanopb).max_size = 6]; /** Identifier for the display */
+}
+
+/**
+ * DisplayRemove removes an existing display.
+ */
+message DisplayRemove {
+  string name = 1[(nanopb).max_size = 6]; /** Identifier for the display. */
+}
+
+/**
+ * DisplayWrite writes content to a display.
+ */
+message DisplayWrite {
+  string name     = 1[(nanopb).max_size = 6]; /** Identifier for the display. */
+  string message  = 2[(nanopb).max_size = 6]; /** Message to write. */
+  oneof options {
+    EPDWriteOptions epd_options = 3; /** Options for writing to EPD displays */
+  }
+}
+
+// ============================================================================
+// Response Messages
+// ============================================================================
+
+/**
+ * DisplayAddedorReplaced confirms a display was added or replaced.
+ */
+message DisplayAddedorReplaced {
+  bool did_add = 1; /** Indicates if a display was added */
+}
+
+/**
+ * DisplayRemoved confirms a display was removed.
+ */
+message DisplayRemoved {
+  bool did_remove = 1; /** Indicates if a display was removed */
+}

--- a/proto/wippersnapper/display/v1/display.proto
+++ b/proto/wippersnapper/display/v1/display.proto
@@ -70,8 +70,10 @@ message EPDWriteOptions {
  * It includes the mode, dimensions, and panel type.
  */
 message EPDConfig {
-  EPDMode mode = 1; /** The mode of the EPD display */
+  EPDMode mode            = 1; /** The mode of the EPD display */
   EPDWriteOptions options = 2; /** Options for writing to the EPD */
+  int32 width             = 3;   /** Width of the EPD display, in pixels */
+  int32 height            = 4;   /** Height of the EPD display, in pixels */
 }
 
 /**

--- a/proto/wippersnapper/display/v1/display.proto
+++ b/proto/wippersnapper/display/v1/display.proto
@@ -106,13 +106,14 @@ message TftConfig {
 message DisplayAddOrReplace {
   DisplayType type       = 1; /** The type of display */
   DisplayDriver driver   = 2; /** The specific driver for the display */
+  string name = 3[(nanopb).max_size = 64]; /** Identifies the display. */
   oneof interface_type {
-    EpdSpiConfig spi_epd = 3; /** SPI configuration for EPD. */
-    TftSpiConfig spi_tft = 4; /** SPI configuration for TFT. */
+    EpdSpiConfig spi_epd = 4; /** SPI configuration for EPD. */
+    TftSpiConfig spi_tft = 5; /** SPI configuration for TFT. */
   }
   oneof config {
-    EPDConfig config_epd = 5; /** Configuration for EPD. */
-    TftConfig config_tft = 6; /** Configuration for TFT. */
+    EPDConfig config_epd = 6; /** Configuration for EPD. */
+    TftConfig config_tft = 7; /** Configuration for TFT. */
   }
 }
 

--- a/proto/wippersnapper/display/v1/display.proto
+++ b/proto/wippersnapper/display/v1/display.proto
@@ -33,43 +33,21 @@ enum EPDMode {
   EPD_MODE_MONO        = 2; /** Monochrome EPD mode */
 }
 
-/**
-* Desired SSD1306 text 'magnification' size.
-*/
-enum SSD1306TextSize {
-  SSD1306_TEXT_SIZE_UNSPECIFIED = 0; /** Unspecified text size. **/
-  SSD1306_TEXT_SIZE_1           = 1; /** Default text size, 6x8px. **/
-  SSD1306_TEXT_SIZE_2           = 2; /** Larger text size option, 12x16px. **/
-}
-
-/**
-* LEDBackpackAlignment represents all text alignment
-* options for LED backpack displays
-*/
-enum LEDBackpackAlignment {
-  LED_BACKPACK_ALIGNMENT_UNSPECIFIED = 0; /** Unspecified alignment option. **/
-  LED_BACKPACK_ALIGNMENT_LEFT        = 1; /** (Default) Left-aligned. **/
-  LED_BACKPACK_ALIGNMENT_RIGHT       = 2; /** Right-aligned. **/
-}
-
 // ============================================================================
 // Configuration Messages
 // ============================================================================
 
 /**
- * SpiConfig contains the configuration for SPI-based displays.
+ * EpdSpiConfig contains the configuration for SPI-based EPD displays.
  * Includes the SPI bus number and pin assignments.
  */
-message SpiConfig {
+message EpdSpiConfig {
   int32 bus          = 1; /** The SPI bus to use */
   string pin_dc      = 2[(nanopb).max_size = 6]; /** Pin for data/command */
   string pin_rst     = 3[(nanopb).max_size = 6]; /** Pin for reset */
   string pin_cs      = 4[(nanopb).max_size = 6]; /** Pin for chip select */
   string pin_sram_cs = 5[(nanopb).max_size = 6]; /** Pin for SRAM chip select */
   string pin_busy    = 6[(nanopb).max_size = 6]; /** Pin for busy signal */
-  string pin_mosi    = 7[(nanopb).max_size = 6]; /** Pin for MOSI */
-  string pin_sck     = 8[(nanopb).max_size = 6]; /** Pin for SCK */
-  string pin_miso    = 9[(nanopb).max_size = 6]; /** Pin for MISO */
 }
 
 /**
@@ -87,39 +65,24 @@ message EPDWriteOptions {
   int32 text_size = 1; /** Scale factor for text (1 = 6x8px, 2 = 12x16px,...) */
 }
 
+/**
+ * TftSpiConfig contains the configuration for SPI TFT displays.
+ * Includes the SPI bus number and pin assignments.
+ */
+message TftSpiConfig {
+  int32 bus          = 1; /** The SPI bus to use */
+  string pin_cs      = 2[(nanopb).max_size = 6]; /** Pin for chip select */
+  string pin_dc      = 3[(nanopb).max_size = 6]; /** Pin for data/command */
+  string pin_mosi    = 4[(nanopb).max_size = 6]; /** Pin for MOSI */
+  string pin_sck     = 5[(nanopb).max_size = 6]; /** Pin for SCK */
+  string pin_rst     = 6[(nanopb).max_size = 6]; /** Pin for reset */
+  string pin_miso    = 7[(nanopb).max_size = 6]; /** Pin for MISO */
+}
+
 message TftConfig {
   int32 width  = 1;   /** Width of the TFT display in pixels */
   int32 height = 2;   /** Height of the TFT display in pixels */
   int32 rotation = 3; /** Rotation of the display (0-3) */
-}
-
-message I2cConfig {
-  wippersnapper.i2c.v1.I2CDeviceInitRequest i2c = 1; /** I2C configuration */
-}
-
-/**
-* SSD1306Config represents the configuration for a SSD1306 OLED display.
-*/
-message SSD1306Config {
-  uint32 width              = 1; /** Width of the display. **/
-  uint32 height             = 2; /** Height of the display. **/
-  SSD1306TextSize text_size = 3; /** Desired text 'magnification' size. **/
-}
-
-/**
-* LEDBackpackConfig represents the configuration for a LED backpack display.
-*/
-message LEDBackpackConfig {
-  int32 brightness                = 1; /** Desired brightness of the LED backpack, from 0 (off) to 15 (full brightness). **/
-  LEDBackpackAlignment alignment  = 2; /** Desired text alignment for the LED backpack. **/
-}
-
-/**
-* CharLCDConfig represents the configuration for a character LCD display.
-*/
-message CharLCDConfig {
-  uint32 rows            = 1; /** Number of rows for the character LCD. **/
-  uint32 columns         = 2; /** Number of columns for the character LCD. **/
 }
 
 // ============================================================================
@@ -133,15 +96,12 @@ message DisplayAddOrReplace {
   DisplayType type = 1; /** The type of display */
   string name = 2[(nanopb).max_size = 64]; /** Identifier for the display */
   oneof interface_type {
-    SpiConfig cfg_spi = 3; /** SPI config for EPD */
-    I2cConfig cfg_i2c = 4; /** I2C device config */
+    EpdSpiConfig spi_epd = 3; /** SPI configuration for EPD */
+    TftSpiConfig spi_tft = 4; /** SPI configuration for TFT */
   }
   oneof config {
-    EPDConfig config_epd = 5; /** Config for EPD display */
-    TftConfig config_tft = 6; /** Config for TFT display */
-    SSD1306Config config_ssd1306 = 7; /** Config for SSD1306 OLED */
-    LEDBackpackConfig config_led_backpack = 8; /** Config for LED backpack. */
-    CharLCDConfig config_char_lcd = 9; /** Config for character LCD. */
+    EPDConfig config_epd = 5; /** Configuration for EPD display */
+    TftConfig config_tft = 6; /** Configuration for TFT display */
   }
 }
 

--- a/proto/wippersnapper/display/v1/display.proto
+++ b/proto/wippersnapper/display/v1/display.proto
@@ -20,6 +20,7 @@ enum DisplayType {
   DISPLAY_TYPE_UNSPECIFIED = 0; /** Unspecified display type. */
   DISPLAY_TYPE_OLED        = 1; /** OLED display type */
   DISPLAY_TYPE_EPD         = 2; /** EPD display type */
+  DISPLAY_TYPE_TFT         = 3; /** TFT display type */
 }
 
 /**

--- a/proto/wippersnapper/display/v1/display.proto
+++ b/proto/wippersnapper/display/v1/display.proto
@@ -33,25 +33,6 @@ enum EPDMode {
   EPD_MODE_MONO        = 2; /** Monochrome EPD mode */
 }
 
-/**
-* Desired SSD1306 text 'magnification' size.
-*/
-enum SSD1306TextSize {
-  SSD1306_TEXT_SIZE_UNSPECIFIED = 0; /** Unspecified text size. **/
-  SSD1306_TEXT_SIZE_1           = 1; /** Default text size, 6x8px. **/
-  SSD1306_TEXT_SIZE_2           = 2; /** Larger text size option, 12x16px. **/
-}
-
-/**
-* LEDBackpackAlignment represents all text alignment
-* options for LED backpack displays
-*/
-enum LEDBackpackAlignment {
-  LED_BACKPACK_ALIGNMENT_UNSPECIFIED = 0; /** Unspecified alignment option. **/
-  LED_BACKPACK_ALIGNMENT_LEFT        = 1; /** (Default) Left-aligned. **/
-  LED_BACKPACK_ALIGNMENT_RIGHT       = 2; /** Right-aligned. **/
-}
-
 // ============================================================================
 // Configuration Messages
 // ============================================================================
@@ -110,8 +91,8 @@ message OledConfig {
 * LEDBackpackConfig represents the configuration for a LED backpack display.
 */
 message LEDBackpackConfig {
-  int32 brightness                = 1; /** Desired brightness of the LED backpack, from 0 (off) to 15 (full brightness). **/
-  LEDBackpackAlignment alignment  = 2; /** Desired text alignment for the LED backpack. **/
+  int32 brightness = 1; /** Desired brightness, from off to full brightness. **/
+  uint32 alignment = 2; /** Desired text alignment for the LED backpack. **/
 }
 
 /**

--- a/proto/wippersnapper/display/v1/display.proto
+++ b/proto/wippersnapper/display/v1/display.proto
@@ -64,6 +64,26 @@ message EPDWriteOptions {
   int32 text_size = 1; /** Scale factor for text (1 = 6x8px, 2 = 12x16px,...) */
 }
 
+/**
+ * TftSpiConfig contains the configuration for SPI TFT displays.
+ * Includes the SPI bus number and pin assignments.
+ */
+message TftSpiConfig {
+  int32 bus          = 1; /** The SPI bus to use */
+  string pin_cs      = 2[(nanopb).max_size = 6]; /** Pin for chip select */
+  string pin_dc      = 3[(nanopb).max_size = 6]; /** Pin for data/command */
+  string pin_mosi    = 4[(nanopb).max_size = 6]; /** Pin for MOSI */
+  string pin_sck     = 5[(nanopb).max_size = 6]; /** Pin for SCK */
+  string pin_rst     = 6[(nanopb).max_size = 6]; /** Pin for reset */
+  string pin_miso    = 7[(nanopb).max_size = 6]; /** Pin for MISO */
+}
+
+message TftConfig {
+  int32 width  = 1;   /** Width of the TFT display in pixels */
+  int32 height = 2;   /** Height of the TFT display in pixels */
+  int32 rotation = 3; /** Rotation of the display (0-3) */
+}
+
 // ============================================================================
 // Request Messages
 // ============================================================================
@@ -76,9 +96,11 @@ message DisplayAddOrReplace {
   string name = 2[(nanopb).max_size = 64]; /** Identifier for the display */
   oneof interface_type {
     EpdSpiConfig spi_epd = 3; /** SPI configuration for EPD */
+    TftSpiConfig spi_tft = 4; /** SPI configuration for TFT */
   }
   oneof config {
-    EPDConfig epd_config = 4; /** Configuration for EPD display */
+    EPDConfig config_epd = 5; /** Configuration for EPD display */
+    TftConfig config_tft = 6; /** Configuration for TFT display */
   }
 }
 

--- a/proto/wippersnapper/display/v1/display.proto
+++ b/proto/wippersnapper/display/v1/display.proto
@@ -127,9 +127,9 @@ message DisplayWrite {
 // ============================================================================
 
 /**
- * DisplayAddedorReplaced confirms a display was added or replaced.
+ * DisplayAddedOrReplaced confirms a display was added or replaced.
  */
-message DisplayAddedorReplaced {
+message DisplayAddedOrReplaced {
   string name  = 1[(nanopb).max_size = 64]; /** Identifier for the display. */
   bool did_add = 2; /** Indicates if a display was added */
 }

--- a/proto/wippersnapper/display/v1/display.proto
+++ b/proto/wippersnapper/display/v1/display.proto
@@ -5,8 +5,8 @@
 syntax = "proto3";
 
 package wippersnapper.display.v1;
-//import "nanopb/nanopb.proto";
-import "i2c.proto";
+import "nanopb/nanopb.proto";
+import "wippersnapper/i2c/v1/i2c.proto";
 
 // ============================================================================
 // Enums

--- a/proto/wippersnapper/display/v1/display.proto
+++ b/proto/wippersnapper/display/v1/display.proto
@@ -98,12 +98,12 @@ message I2cConfig {
 }
 
 /**
-* SSD1306Config represents the configuration for a SSD1306 OLED display.
+* OledConfig represents the configuration for an OLED display.
 */
-message SSD1306Config {
-  uint32 width              = 1; /** Width of the display. **/
-  uint32 height             = 2; /** Height of the display. **/
-  SSD1306TextSize text_size = 3; /** Desired text 'magnification' size. **/
+message OledConfig {
+  uint32 width    = 1; /** Width of the display. **/
+  uint32 height   = 2; /** Height of the display. **/
+  int32 text_size = 3; /** Desired text 'magnification' size. **/
 }
 
 /**
@@ -139,7 +139,7 @@ message DisplayAddOrReplace {
   oneof config {
     EPDConfig config_epd = 5; /** Config for EPD display */
     TftConfig config_tft = 6; /** Config for TFT display */
-    SSD1306Config config_ssd1306 = 7; /** Config for SSD1306 OLED */
+    OledConfig config_oled = 7; /** Config for SSD1306 OLED */
     LEDBackpackConfig config_led_backpack = 8; /** Config for LED backpack. */
     CharLCDConfig config_char_lcd = 9; /** Config for character LCD. */
   }

--- a/proto/wippersnapper/i2c/v1/i2c.proto
+++ b/proto/wippersnapper/i2c/v1/i2c.proto
@@ -93,8 +93,6 @@ message I2CDeviceInitRequest {
   uint32 i2c_device_address                                 = 3; /** The 7-bit I2C address of the device on the bus. */
   string i2c_device_name                                    = 4[(nanopb).max_size = 256]; /** The I2C device's name, MUST MATCH the name on the JSON definition file on https://github.com/adafruit/Wippersnapper_Components. */
   repeated I2CDeviceSensorProperties i2c_device_properties  = 5[(nanopb).max_count = 15]; /** Properties of each sensor on the I2C device. */
-  bool is_output_device                                     = 6; /** True if the I2C device is an I2C output device, False otherwise (default). */
-  I2COutputAdd i2c_output_add                               = 7; /** The configuration for an I2C output device. */
 }
 
 /**
@@ -206,99 +204,4 @@ message SensorEvent {
 message I2CDeviceEvent {
   uint32 sensor_address              = 1; /** The 7-bit I2C address of the I2C device. */
   repeated SensorEvent sensor_event  = 2[(nanopb).max_count = 15]; /** A, optionally repeated, SensorEvent from a sensor. */
-}
-
-/**
-* I2CDeviceOutputWrite represents a request to write to an I2C output device.
-* NOTE: This message is similar to the I2CDeviceOutputWrite message on
-* the api-v2 branch but NOT identical.
-*/
-message I2CDeviceOutputWrite {
-  uint32 i2c_device_address             = 1; /** The 7-bit I2C address of the device on the bus. */
-  string i2c_device_name                = 2[(nanopb).max_size = 256]; /** The I2C device's name, MUST MATCH the name on the JSON definition file on https://github.com/adafruit/Wippersnapper_Components. */
-  oneof output_msg {
-    LEDBackpackWrite write_led_backpack = 3; /** Optional - If the I2C device is a LED backpack, fill this field. **/
-    CharLCDWrite write_char_lcd         = 4; /** Optional - If the I2C device is a character LCD, fill this field. **/
-    SSD1306Write write_ssd1306          = 5; /** Optional - If the I2C device is a SSD1306 OLED display, fill this field. **/
-  }
-}
-
-///*** I2C Output Device Messages (from i2c_output.proto in api v2) ***///
-
-/**
-* LEDBackpackAlignment represents all text alignment
-* options for LED backpack displays
-*/
-enum LEDBackpackAlignment {
-  LED_BACKPACK_ALIGNMENT_UNSPECIFIED = 0; /** Unspecified alignment option. **/
-  LED_BACKPACK_ALIGNMENT_LEFT        = 1; /** (Default) Left-aligned. **/
-  LED_BACKPACK_ALIGNMENT_RIGHT       = 2; /** Right-aligned. **/
-}
-
-/**
-* Desired SSD1306 text 'magnification' size.
-*/
-enum SSD1306TextSize {
-  SSD1306_TEXT_SIZE_UNSPECIFIED = 0; /** Unspecified text size. **/
-  SSD1306_TEXT_SIZE_1           = 1; /** Default text size, 6x8px. **/
-  SSD1306_TEXT_SIZE_2           = 2; /** Larger text size option, 12x16px. **/
-}
-
-/**
-* LEDBackpackConfig represents the configuration for a LED backpack display.
-*/
-message LEDBackpackConfig {
-  int32 brightness                = 1; /** Desired brightness of the LED backpack, from 0 (off) to 15 (full brightness). **/
-  LEDBackpackAlignment alignment  = 2; /** Desired text alignment for the LED backpack. **/
-}
-
-/**
-* CharLCDConfig represents the configuration for a character LCD display.
-*/
-message CharLCDConfig {
-  uint32 rows            = 1; /** Number of rows for the character LCD. **/
-  uint32 columns         = 2; /** Number of columns for the character LCD. **/
-}
-
-/**
-* SSD1306Config represents the configuration for a SSD1306 OLED display.
-*/
-message SSD1306Config {
-  uint32 width              = 1; /** Width of the display. **/
-  uint32 height             = 2; /** Height of the display. **/
-  SSD1306TextSize text_size = 3; /** Desired text 'magnification' size. **/
-}
-
-/**
-* I2COutputAdd represents a request from the broker to add an I2C output device to a device.
-*/
-message I2COutputAdd {
-  oneof config {
-    LEDBackpackConfig led_backpack_config = 1; /** Configuration for LED backpack. **/
-    CharLCDConfig char_lcd_config         = 2; /** Configuration for character LCD. **/
-    SSD1306Config ssd1306_config          = 3; /** Configuration for SSD1306 OLED display. **/
-  }
-}
-
-/**
-* LEDBackpackWrite represents a request from the broker to write a message to a LED backpack.
-*/
-message LEDBackpackWrite {
-  string message = 1 [(nanopb).max_size = 128]; /** Message to write to the LED backpack. **/
-}
-
-/**
-* CharLCDWrite represents a request from the broker to write to a character LCD.
-*/
-message CharLCDWrite {
-  string message         = 1 [(nanopb).max_size = 128]; /** Message to write to the character LCD. **/
-  bool enable_backlight  = 2; /** Optional field to enable/disable the backlight. Should be its own feed (0 is off, 1 is on).**/
-}
-
-/**
-* SSD1306Write represents a request from the broker to
-* write to a SSD1306 OLED display.
-*/
-message SSD1306Write {
-  string message = 1 [(nanopb).max_size = 256]; /** Message to write to a SSD1306 OLED display. **/
 }

--- a/proto/wippersnapper/i2c/v1/i2c.proto
+++ b/proto/wippersnapper/i2c/v1/i2c.proto
@@ -93,6 +93,8 @@ message I2CDeviceInitRequest {
   uint32 i2c_device_address                                 = 3; /** The 7-bit I2C address of the device on the bus. */
   string i2c_device_name                                    = 4[(nanopb).max_size = 256]; /** The I2C device's name, MUST MATCH the name on the JSON definition file on https://github.com/adafruit/Wippersnapper_Components. */
   repeated I2CDeviceSensorProperties i2c_device_properties  = 5[(nanopb).max_count = 15]; /** Properties of each sensor on the I2C device. */
+  bool is_output_device                                     = 6; /** True if the I2C device is an I2C output device, False otherwise (default). */
+  I2COutputAdd i2c_output_add                               = 7; /** The configuration for an I2C output device. */
 }
 
 /**
@@ -204,4 +206,99 @@ message SensorEvent {
 message I2CDeviceEvent {
   uint32 sensor_address              = 1; /** The 7-bit I2C address of the I2C device. */
   repeated SensorEvent sensor_event  = 2[(nanopb).max_count = 15]; /** A, optionally repeated, SensorEvent from a sensor. */
+}
+
+/**
+* I2CDeviceOutputWrite represents a request to write to an I2C output device.
+* NOTE: This message is similar to the I2CDeviceOutputWrite message on
+* the api-v2 branch but NOT identical.
+*/
+message I2CDeviceOutputWrite {
+  uint32 i2c_device_address             = 1; /** The 7-bit I2C address of the device on the bus. */
+  string i2c_device_name                = 2[(nanopb).max_size = 256]; /** The I2C device's name, MUST MATCH the name on the JSON definition file on https://github.com/adafruit/Wippersnapper_Components. */
+  oneof output_msg {
+    LEDBackpackWrite write_led_backpack = 3; /** Optional - If the I2C device is a LED backpack, fill this field. **/
+    CharLCDWrite write_char_lcd         = 4; /** Optional - If the I2C device is a character LCD, fill this field. **/
+    SSD1306Write write_ssd1306          = 5; /** Optional - If the I2C device is a SSD1306 OLED display, fill this field. **/
+  }
+}
+
+///*** I2C Output Device Messages (from i2c_output.proto in api v2) ***///
+
+/**
+* LEDBackpackAlignment represents all text alignment
+* options for LED backpack displays
+*/
+enum LEDBackpackAlignment {
+  LED_BACKPACK_ALIGNMENT_UNSPECIFIED = 0; /** Unspecified alignment option. **/
+  LED_BACKPACK_ALIGNMENT_LEFT        = 1; /** (Default) Left-aligned. **/
+  LED_BACKPACK_ALIGNMENT_RIGHT       = 2; /** Right-aligned. **/
+}
+
+/**
+* Desired SSD1306 text 'magnification' size.
+*/
+enum SSD1306TextSize {
+  SSD1306_TEXT_SIZE_UNSPECIFIED = 0; /** Unspecified text size. **/
+  SSD1306_TEXT_SIZE_1           = 1; /** Default text size, 6x8px. **/
+  SSD1306_TEXT_SIZE_2           = 2; /** Larger text size option, 12x16px. **/
+}
+
+/**
+* LEDBackpackConfig represents the configuration for a LED backpack display.
+*/
+message LEDBackpackConfig {
+  int32 brightness                = 1; /** Desired brightness of the LED backpack, from 0 (off) to 15 (full brightness). **/
+  LEDBackpackAlignment alignment  = 2; /** Desired text alignment for the LED backpack. **/
+}
+
+/**
+* CharLCDConfig represents the configuration for a character LCD display.
+*/
+message CharLCDConfig {
+  uint32 rows            = 1; /** Number of rows for the character LCD. **/
+  uint32 columns         = 2; /** Number of columns for the character LCD. **/
+}
+
+/**
+* SSD1306Config represents the configuration for a SSD1306 OLED display.
+*/
+message SSD1306Config {
+  uint32 width              = 1; /** Width of the display. **/
+  uint32 height             = 2; /** Height of the display. **/
+  SSD1306TextSize text_size = 3; /** Desired text 'magnification' size. **/
+}
+
+/**
+* I2COutputAdd represents a request from the broker to add an I2C output device to a device.
+*/
+message I2COutputAdd {
+  oneof config {
+    LEDBackpackConfig led_backpack_config = 1; /** Configuration for LED backpack. **/
+    CharLCDConfig char_lcd_config         = 2; /** Configuration for character LCD. **/
+    SSD1306Config ssd1306_config          = 3; /** Configuration for SSD1306 OLED display. **/
+  }
+}
+
+/**
+* LEDBackpackWrite represents a request from the broker to write a message to a LED backpack.
+*/
+message LEDBackpackWrite {
+  string message = 1 [(nanopb).max_size = 128]; /** Message to write to the LED backpack. **/
+}
+
+/**
+* CharLCDWrite represents a request from the broker to write to a character LCD.
+*/
+message CharLCDWrite {
+  string message         = 1 [(nanopb).max_size = 128]; /** Message to write to the character LCD. **/
+  bool enable_backlight  = 2; /** Optional field to enable/disable the backlight. Should be its own feed (0 is off, 1 is on).**/
+}
+
+/**
+* SSD1306Write represents a request from the broker to
+* write to a SSD1306 OLED display.
+*/
+message SSD1306Write {
+  string message = 1 [(nanopb).max_size = 256]; /** Message to write to a SSD1306 OLED display. **/
 }

--- a/proto/wippersnapper/signal/v1/signal.proto
+++ b/proto/wippersnapper/signal/v1/signal.proto
@@ -74,6 +74,7 @@ message I2CRequest {
     wippersnapper.i2c.v1.I2CDeviceDeinitRequest req_i2c_device_deinit       = 5;
     wippersnapper.i2c.v1.I2CDeviceUpdateRequest req_i2c_device_update       = 6;
     wippersnapper.i2c.v1.I2CDeviceInitRequests req_i2c_device_init_requests = 7;
+    wippersnapper.i2c.v1.I2CDeviceOutputWrite req_i2c_device_out_write      = 8;
   }
 }
 

--- a/proto/wippersnapper/signal/v1/signal.proto
+++ b/proto/wippersnapper/signal/v1/signal.proto
@@ -201,7 +201,7 @@ message DisplayRequest {
 message DisplayResponse {
   option (nanopb_msgopt).submsg_callback = true;
   oneof payload {
-    wippersnapper.display.v1.DisplayAddedorReplaced display_added = 1;
+    wippersnapper.display.v1.DisplayAddedOrReplaced display_added = 1;
     wippersnapper.display.v1.DisplayRemoved display_removed       = 2;
   }
 }

--- a/proto/wippersnapper/signal/v1/signal.proto
+++ b/proto/wippersnapper/signal/v1/signal.proto
@@ -74,7 +74,6 @@ message I2CRequest {
     wippersnapper.i2c.v1.I2CDeviceDeinitRequest req_i2c_device_deinit       = 5;
     wippersnapper.i2c.v1.I2CDeviceUpdateRequest req_i2c_device_update       = 6;
     wippersnapper.i2c.v1.I2CDeviceInitRequests req_i2c_device_init_requests = 7;
-    wippersnapper.i2c.v1.I2CDeviceOutputWrite req_i2c_device_out_write      = 8;
   }
 }
 

--- a/proto/wippersnapper/signal/v1/signal.proto
+++ b/proto/wippersnapper/signal/v1/signal.proto
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2020-2021 Brent Rubell for Adafruit Industries
+// SPDX-FileCopyrightText: 2020-2025 Brent Rubell for Adafruit Industries
 // SPDX-License-Identifier: MIT
 syntax = "proto3";
 
@@ -15,6 +15,7 @@ import "wippersnapper/pwm/v1/pwm.proto";
 import "wippersnapper/ds18x20/v1/ds18x20.proto";
 import "wippersnapper/pixels/v1/pixels.proto";
 import "wippersnapper/uart/v1/uart.proto";
+import "wippersnapper/display/v1/display.proto";
 
 /**
 * UARTRequest represents a UART command sent to a device.
@@ -179,5 +180,28 @@ message PWMResponse {
   option (nanopb_msgopt).submsg_callback = true;
   oneof payload {
     wippersnapper.pwm.v1.PWMAttachResponse attach_response = 1;
+  }
+}
+
+/**
+* DisplayRequest represents a broker's request across the display sub-topic.
+*/
+message DisplayRequest {
+  option (nanopb_msgopt).submsg_callback = true;
+  oneof payload {
+    wippersnapper.display.v1.DisplayAddOrReplace display_add = 1;
+    wippersnapper.display.v1.DisplayRemove display_remove    = 2;
+    wippersnapper.display.v1.DisplayWrite display_write      = 3;
+  }
+}
+
+/**
+* DisplayResponse represents a devices's response across the display sub-topic.
+*/
+message DisplayResponse {
+  option (nanopb_msgopt).submsg_callback = true;
+  oneof payload {
+    wippersnapper.display.v1.DisplayAddedorReplaced display_added = 1;
+    wippersnapper.display.v1.DisplayRemoved display_removed       = 2;
   }
 }


### PR DESCRIPTION
This pull request introduces a new protocol buffer definition for display management in WipperSnapper API v1, integrating display support into the existing messaging system. 

### Coverage
- Implemented new `display.proto` API
- Modified `signal.proto` to include messages from `display.proto` in `MsgRequest`/`MsgResponse` format.
- Added `display.md` API documentation

### Implementation Details:
cc @lorennorman 
I implemented with YAGNI in mind so the changes are only for EPD. However, the API is flexible enough to extend to TFTs and (existing) OLED, LED matrix and LCD character displays.

This will require two extra MQTT topics for implementing the `DisplayRequest` and `DisplayResponse` messages:
- `{USER}/wprsnpr/io-wipper-{UID}/signals/broker/display` - `DisplayRequest` messages should be transmitted over this topic.
- 
- `{USER}/wprsnpr/io-wipper-{UID}/signals/device/display` - `DisplayResponse` messages should be transmitted over this topic
- The file `display.md` provides sequence diagrams for the Request and Response messages.