### PR TITLE
Add EPD UC8253 driver to display.proto

### DIFF
--- a/proto/wippersnapper/display/v1/display.proto
+++ b/proto/wippersnapper/display/v1/display.proto
@@ -39,6 +39,7 @@ enum DisplayDriver {
   DISPLAY_DRIVER_EPD_SSD1680 = 1; /** EPD SSD1680 driver */
   DISPLAY_DRIVER_EPD_ILI0373 = 2; /** EPD SSD167 driver */
   DISPLAY_DRIVER_TFT_ST7789  = 3; /** TFT ST7789 driver */
+  DISPLAY_DRIVER_EPD_UC8253  = 4; /** EPD UC8253 driver */
 }
 
 // ============================================================================


### PR DESCRIPTION
Want to test locally if the proto not being added affects the display init message