### PR TITLE
Add - Sleep Modes

### DIFF
--- a/proto/wippersnapper/checkin.proto
+++ b/proto/wippersnapper/checkin.proto
@@ -38,7 +38,7 @@ message D2B {
 message Request {
   string hardware_uid     = 1; /** Identifies the client's physical hardware (board name + last 3 of NIC's MAC address). */
   string firmware_version = 2; /** Identifies the client's firmware version. */
-  ws.sleep.Wakeup wake_cause = 3; /** Optional wakeup cause metadata for low-power mode. */
+  ws.sleep.Wake wake_cause = 3; /** Optional wakeup cause metadata for low-power mode. */
 }
 
 /**

--- a/proto/wippersnapper/checkin.proto
+++ b/proto/wippersnapper/checkin.proto
@@ -10,6 +10,7 @@ import "i2c.proto";
 import "pixels.proto";
 import "pwm.proto";
 import "servo.proto";
+import "sleep.proto";
 import "uart.proto";
 
 /**
@@ -73,6 +74,7 @@ message ComponentAdd {
     ws.ds18x20.Add ds18x20        = 6;
     ws.uart.Add uart              = 7;
     ws.i2c.DeviceAddOrReplace i2c = 8;
+    ws.sleep.Enter sleep          = 9;
   }
 }
 

--- a/proto/wippersnapper/checkin.proto
+++ b/proto/wippersnapper/checkin.proto
@@ -50,7 +50,7 @@ message Response {
   float reference_voltage  = 4; /** Specifies the hardware's default reference voltage. */
 
   repeated ComponentAdd component_adds = 5; /** A list of components to set up and initialize during checkin */
-
+  ws.sleep.Enter sleep                 = 6; /** Sleep configuration for the device */
   /**
    * Response. Specifies if the hardware definiton is within the database.
    */

--- a/proto/wippersnapper/checkin.proto
+++ b/proto/wippersnapper/checkin.proto
@@ -38,6 +38,7 @@ message D2B {
 message Request {
   string hardware_uid     = 1; /** Identifies the client's physical hardware (board name + last 3 of NIC's MAC address). */
   string firmware_version = 2; /** Identifies the client's firmware version. */
+  ws.sleep.Wakeup wake_cause = 3; /** Optional wakeup cause metadata for low-power mode. */
 }
 
 /**

--- a/proto/wippersnapper/signal.proto
+++ b/proto/wippersnapper/signal.proto
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2020-2024 Brent Rubell, Loren Norman for Adafruit Industries
+// SPDX-FileCopyrightText: 2020-2025 Brent Rubell, Loren Norman for Adafruit Industries
 // SPDX-License-Identifier: MIT
 syntax = "proto3";
 package ws.signal;
@@ -11,6 +11,7 @@ import "i2c.proto";
 import "pixels.proto";
 import "pwm.proto";
 import "servo.proto";
+import "sleep.proto";
 import "uart.proto";
 import "gps.proto";
 
@@ -23,10 +24,11 @@ import "gps.proto";
 message BrokerToDevice {
   oneof payload {
     // System Events
-    ws.error.ErrorB2D error = 10;
+    ws.error.ErrorB2D error    = 10;
 
     // Device Interactions
     ws.checkin.B2D checkin     = 20;
+    ws.sleep.B2D sleep         = 21;
 
     // Component Interactions
     ws.digitalio.B2D digitalio = 30;
@@ -49,10 +51,11 @@ message BrokerToDevice {
 message DeviceToBroker {
   oneof payload {
     // System Events
-    ws.error.ErrorD2B error = 10;
+    ws.error.ErrorD2B error    = 10;
 
     // Device Interactions
     ws.checkin.D2B checkin     = 20;
+    ws.sleep.D2B sleep         = 21;
 
     // Component Interactions
     ws.digitalio.D2B digitalio = 30;

--- a/proto/wippersnapper/sleep.options
+++ b/proto/wippersnapper/sleep.options
@@ -1,0 +1,2 @@
+# uart.options
+ws.sleep.PinConfig.name         max_size: 32

--- a/proto/wippersnapper/sleep.options
+++ b/proto/wippersnapper/sleep.options
@@ -1,2 +1,2 @@
 # uart.options
-ws.sleep.PinConfig.name         max_size: 32
+ws.sleep.Ext0Config.name         max_size: 32

--- a/proto/wippersnapper/sleep.proto
+++ b/proto/wippersnapper/sleep.proto
@@ -98,10 +98,11 @@ message PinConfig {
  * Contains configuration to enter a sleep mode.
  */
 message Enter {
-  SleepMode mode      = 1; /** Sleep mode. */
-  WakeupSource wakeup = 2; /** Wakeup source. */
+  bool lock           = 1; /** Tells the device if it is entering sleep or not. */
+  SleepMode mode      = 2; /** Sleep mode. */
+  WakeupSource wakeup = 3; /** Wakeup source. */
   oneof config {
-    TimerConfig timer = 3; /** Timer configuration for wakeup source. */
-    PinConfig pin     = 4; /** Pin configuration for wakeup source. */
+    TimerConfig timer = 4; /** Timer configuration for wakeup source. */
+    PinConfig pin     = 5; /** Pin configuration for wakeup source. */
   }
 }

--- a/proto/wippersnapper/sleep.proto
+++ b/proto/wippersnapper/sleep.proto
@@ -25,15 +25,6 @@ enum EspWakeCause {
 }
 
 /**
- * Device's wakeup sources
- */
-enum WakeupSource {
-  W_UNSPECIFIED = 0; /** Wakeup source is unspecified. */
-  W_TIMER       = 1; /** Wakeup source is a timer. */
-  W_PIN         = 2; /** Wakeup source is a pin. */
-}
-
-/**
  * Device sleep modes
  */
 enum SleepMode {
@@ -100,10 +91,9 @@ message PinConfig {
 message Enter {
   bool lock           = 1; /** Tells the device if it is entering sleep or not. */
   SleepMode mode      = 2; /** Sleep mode. */
-  WakeupSource wakeup = 3; /** Wakeup source. */
   oneof config {
-    TimerConfig timer = 4; /** Timer configuration for wakeup source. */
-    PinConfig pin     = 5; /** Pin configuration for wakeup source. */
+    TimerConfig timer = 3; /** Timer configuration for wakeup source. */
+    PinConfig pin     = 4; /** Pin configuration for wakeup source. */
   }
-  uint32 run_duration = 6; /** Duration the app loop is actively running, in seconds. */
+  uint32 run_duration = 5; /** Duration the app loop is actively running, in seconds. */
 }

--- a/proto/wippersnapper/sleep.proto
+++ b/proto/wippersnapper/sleep.proto
@@ -95,5 +95,4 @@ message Enter {
     TimerConfig timer = 3; /** Timer configuration for wakeup source. */
     Ext0Config ext0   = 4; /** EXT0 RTC configuration for wakeup source. */
   }
-  uint32 run_duration = 5; /** Duration the app loop is actively running, in seconds. */
 }

--- a/proto/wippersnapper/sleep.proto
+++ b/proto/wippersnapper/sleep.proto
@@ -105,4 +105,5 @@ message Enter {
     TimerConfig timer = 4; /** Timer configuration for wakeup source. */
     PinConfig pin     = 5; /** Pin configuration for wakeup source. */
   }
+  uint32 run_duration = 6; /** Duration the app loop is actively running, in seconds. */
 }

--- a/proto/wippersnapper/sleep.proto
+++ b/proto/wippersnapper/sleep.proto
@@ -1,0 +1,99 @@
+// SPDX-FileCopyrightText: 2025 Brent Rubell for Adafruit Industries
+// SPDX-License-Identifier: MIT
+syntax = "proto3";
+package ws.sleep;
+
+/**
+ * Wakeup (post-sleep) causes for ES32x chips.
+ */
+enum EspWakeCause {
+  ESP_UNSPECIFIED     = 0;  /** In case of deep sleep, reset was not caused by exit from deep sleep. */
+  ESP_ALL             = 1;  /** Not a wakeup cause, used to disable all wakeup sources with esp_sleep_disable_wakeup_source. */
+  ESP_EXT0            = 2;  /** Wakeup caused by external signal using RTC_IO. */
+  ESP_EXT1            = 3;  /** Wakeup caused by external signal using RTC_CNTL. */
+  ESP_TIMER           = 4;  /** Wakeup caused by timer. */
+  ESP_TOUCHPAD        = 5;  /** Wakeup caused by touchpad. */
+  ESP_ULP             = 6;  /** Wakeup caused by ULP program. */
+  ESP_GPIO            = 7;  /** Wakeup caused by GPIO (light sleep only on ESP32, S2 and S3). */
+  ESP_UART            = 8;  /** Wakeup caused by UART (light sleep only). */
+  ESP_WIFI            = 9;  /** Wakeup caused by WIFI (light sleep only). */
+  ESP_COCPU           = 10; /** Wakeup caused by  COCPU int. */
+  ESP_COCPU_TRAP      = 11; /** Wakeup caused by COCPU crash. */
+  ESP_BT              = 12; /** Wakeup caused by BT (light sleep only). */
+  ESP_VAD             = 13; /** Wakeup caused by VAD. */
+  ESP_VBAT_UNDER_VOLT = 14; /** Wakeup caused by VDD_BAT under voltage. */
+}
+
+/**
+ * Device's wakeup sources
+ */
+enum WakeupSource {
+  W_UNSPECIFIED = 0; /** Wakeup source is unspecified. */
+  W_TIMER       = 1; /** Wakeup source is a timer. */
+  W_PIN         = 2; /** Wakeup source is a pin. */
+}
+
+/**
+ * Device sleep modes
+ */
+enum SleepMode {
+  S_UNSPECIFIED = 0; /** Sleep mode is unspecified. */
+  S_LIGHT       = 1; /** Light sleep mode. */
+  S_DEEP        = 2; /** Deep sleep mode. */
+}
+
+/**
+ * BrokerToDevice message envelope
+ */
+message B2D {
+  oneof payload {
+    Enter enter = 1; /** Message containing required information to enter deep sleep. */
+  }
+}
+
+/**
+ * DeviceToBroker message envelope
+ */
+message D2B {
+  oneof payload {
+    Wake wake = 1; /** Wakeup event. */
+  }
+}
+
+/**
+ * Wakeup event message from the device.
+ */
+message Wake {
+  oneof WakeCause {
+    EspWakeCause esp    = 1; /** Wakeup cause for ESP32x MCUs. */
+  }
+  uint32 sleep_duration = 2; /** Calculated duration of the sleep duration, in seconds. */
+}
+
+/**
+ * Timer configuration for wakeup source.
+ */
+message TimerConfig {
+  uint32 duration = 1; /** How long the timer will run before triggering a wakeup, in seconds. */
+}
+
+/**
+ * Pin configuration for wakeup source.
+ */
+message PinConfig {
+  string name = 1; /** Pin to wake up from. */
+  bool level  = 2; /**  Input level which will trigger wakeup (False = low, True = high) */
+  bool pull   = 3; /**  Enable internal pull-up or pull-down resistors */
+}
+
+/**
+ * Contains configuration to enter a sleep mode.
+ */
+message Enter {
+  SleepMode mode      = 1; /** Sleep mode. */
+  WakeupSource wakeup = 2; /** Wakeup source. */
+  oneof config {
+    TimerConfig timer = 3; /** Timer configuration for wakeup source. */
+    PinConfig pin     = 4; /** Pin configuration for wakeup source. */
+  }
+}

--- a/proto/wippersnapper/sleep.proto
+++ b/proto/wippersnapper/sleep.proto
@@ -77,9 +77,9 @@ message TimerConfig {
 }
 
 /**
- * Pin configuration for wakeup source.
+ * Pin configuration for ext0 RTC wakeup source.
  */
-message PinConfig {
+message Ext0Config {
   string name = 1; /** Pin to wake up from. */
   bool level  = 2; /**  Input level which will trigger wakeup (False = low, True = high) */
   bool pull   = 3; /**  Enable internal pull-up or pull-down resistors */
@@ -93,7 +93,7 @@ message Enter {
   SleepMode mode      = 2; /** Sleep mode. */
   oneof config {
     TimerConfig timer = 3; /** Timer configuration for wakeup source. */
-    PinConfig pin     = 4; /** Pin configuration for wakeup source. */
+    Ext0Config ext0   = 4; /** EXT0 RTC configuration for wakeup source. */
   }
   uint32 run_duration = 5; /** Duration the app loop is actively running, in seconds. */
 }

--- a/proto/wippersnapper/sleep.proto
+++ b/proto/wippersnapper/sleep.proto
@@ -56,8 +56,16 @@ message B2D {
  */
 message D2B {
   oneof payload {
-    Wake wake = 1; /** Wakeup event. */
+    Goodnight goodnight = 1; /** Goodnight event. */
+    Wake      wake = 2; /** Wakeup event. */
   }
+}
+
+/**
+ * Goodnight event message from the device.
+ */
+message Goodnight {
+  string message = 1; /** Message indicating the device is going to sleep. */
 }
 
 /**


### PR DESCRIPTION
This pull request adds support for ESP32x sleep functionality to the WipperSnapper API, enabling the option of having low-power WipperSnapper nodes.

Sleep "Mode" Overview
<img width="3605" height="8230" alt="Device Boot and Sleep Cycle-2025-12-19-192226" src="https://github.com/user-attachments/assets/64ae2d61-a548-4ebf-a79b-7ee93497b55b" />


* `message Enter` contains configuration for a node to configure itself for entering a sleep mode.
  * `mode` - Required sleep mode, supports the primary ESP32x sleep modes - Light Sleep and Deep Sleep
    * Note: While this may eventually be automatically selected and filled by the broker depending on the `WakeupSource` and `TimerConfig`'s `duration`. However, I think we'll always want to expose this field (even if we hide it or put it under an "advanced options" dropdown).
  * `WakeupSource` - There are several wakeup sources in the sleep modes. However, we are only supporting timer-based wake (RTC/timer) and pin-based wake (external GPIO)
  * `config` contains `mode` configuration

* `message Goodnight` contains a message to indicate the device is going to sleep. It is published to Adafruit IO. It may eventually be required to expanded to contain a failure state (if the device fails to go into deep sleep).

* `message Wake` - Sent when a device wakes up from sleep. 
  * Contains a wake reason (`EspWakeCause`)
    * We are expecting to expand this to multiple chipsets if they have compatibility, so `WakeCause` is a `oneof`.
  * Contains a calculated sleep duration (may be used to determine drift, or debug if the device actually went to sleep)