### PR TITLE
v2 - Add nested Write events

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,8 @@ jobs:
 
       - name: Lib Dependencies
         run: |
-          pip install protobuf setuptools
+          pip install protobuf
+          pip install setuptools==75.3.4
           go install github.com/pseudomuto/protoc-gen-doc/cmd/protoc-gen-doc@v1.5.1
 
       - name: Env Debug Info

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,9 +16,8 @@ jobs:
 
       - name: Lib Dependencies
         run: |
-          pip install protobuf setuptools setuptools-pkg-resources
+          pip install protobuf setuptools
           go install github.com/pseudomuto/protoc-gen-doc/cmd/protoc-gen-doc@v1.5.1
-          
 
       - name: Env Debug Info
         continue-on-error: true # this is a purely informational step

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,8 +16,9 @@ jobs:
 
       - name: Lib Dependencies
         run: |
-          pip install protobuf setuptools
+          pip install protobuf setuptools setuptools-pkg-resources
           go install github.com/pseudomuto/protoc-gen-doc/cmd/protoc-gen-doc@v1.5.1
+          
 
       - name: Env Debug Info
         continue-on-error: true # this is a purely informational step

--- a/proto/wippersnapper/digitalio.proto
+++ b/proto/wippersnapper/digitalio.proto
@@ -51,7 +51,7 @@ message Add {
   Direction gpio_direction = 2; /** The pin's direction. */
   SampleMode sample_mode   = 3; /** Specifies the pin's sample mode. */
   float period             = 4; /** Time between measurements in seconds, if MODE_TIMER. */
-  bool value               = 5; /** Re-sync only - send the pin's value. */
+  Write write              = 5; /** Optional initial value to write to the pin, used during check-in. */
 }
 
 /**

--- a/proto/wippersnapper/i2c_output.proto
+++ b/proto/wippersnapper/i2c_output.proto
@@ -56,6 +56,11 @@ message Add {
     CharLCDConfig char_lcd_config         = 2; /** Configuration for a character LCD. **/
     OledConfig oled_config                = 3; /** Configuration for an OLED display. **/
   }
+  oneof write {
+    LedBackpackWrite led_backpack_write = 4; /** Optional initial write for a LED backpack, used during check-in. **/
+    CharLCDWrite char_lcd_write         = 5; /** Optional initial write for a character LCD, used during check-in. **/
+    OLEDWrite oled_write                = 6; /** Optional initial write for an OLED display, used during check-in. **/
+  }
 }
 
 /**

--- a/proto/wippersnapper/pixels.proto
+++ b/proto/wippersnapper/pixels.proto
@@ -60,6 +60,7 @@ message Add {
   uint32 brightness        = 4; /** Strand brightness, 0 to 255 */
   string pin_data          = 5; /** Data pin a NeoPixel or DotStar strand is connected to. */
   string pin_dotstar_clock = 6; /** Clock pin a DotStar strand is connected to. */
+  Write write              = 7; /** Optional initial write for a strand of pixels, used during check-in. */
 }
 
 /**

--- a/proto/wippersnapper/pwm.proto
+++ b/proto/wippersnapper/pwm.proto
@@ -32,6 +32,7 @@ message Add {
   string pin       = 1; /** The pin to be attached. */
   int32 frequency  = 2; /** PWM frequency of an analog pin, in Hz. **/
   int32 resolution = 3; /** The resolution of an analog pin, in bits. **/
+  Write write      = 4; /** Optional initial write for a PWM pin, used during check-in. */
 }
 
 /**

--- a/proto/wippersnapper/servo.proto
+++ b/proto/wippersnapper/servo.proto
@@ -31,6 +31,7 @@ message Add {
   int32 freq            = 2; /** The overall PWM frequency, default sent by Adafruit IO is 50Hz. **/
   int32 min_pulse_width = 3; /** The minimum pulse length in uS. Default sent by Adafruit IO is 500uS. **/
   int32 max_pulse_width = 4; /** The maximum pulse length in uS. Default sent by Adafruit IO is 2500uS. **/
+  Write write           = 5; /** Optional initial write for a servo pin, used during check-in. **/
 }
 
 /**

--- a/proto/wippersnapper/uart.proto
+++ b/proto/wippersnapper/uart.proto
@@ -160,6 +160,7 @@ message Descriptor {
 message Add {
   SerialConfig cfg_serial = 1; /** The Serial configuration. */
   DeviceConfig cfg_device = 2; /** The device-specific configuration. */
+  Write write             = 3; /** Optional initial write for a UART device, used during check-in. */
 }
 
 /**


### PR DESCRIPTION
Update PB APIs to require nested `xWrite` inside all `xAdd` messages

Why? We want APIs/components to initialize-on-sync, reducing network overhead and message passing.
