### PR TITLE
V2 Tweaks

### DIFF
--- a/proto/wippersnapper/checkin.proto
+++ b/proto/wippersnapper/checkin.proto
@@ -65,7 +65,7 @@ message Response {
 /**
  * Generic component add message, could contain any *Add message from component protos
  */
-message ComponentAdd {
+message ComponentAdds {
   repeated ws.digitalio.Add digitalio    = 1;
   repeated ws.analogio.Add analogio      = 2;
   repeated ws.servo.Add servo            = 3;

--- a/proto/wippersnapper/checkin.proto
+++ b/proto/wippersnapper/checkin.proto
@@ -38,20 +38,20 @@ message D2B {
 message Request {
   string hardware_uid     = 1; /** Identifies the client's physical hardware (board name + last 3 of NIC's MAC address). */
   string firmware_version = 2; /** Identifies the client's firmware version. */
-  ws.sleep.Wake wake_cause = 3; /** Optional wakeup cause metadata for low-power mode. */
 }
 
 /**
 * Response sends a broker response to the client's Request.
 */
 message Response {
-  Response response        = 1; /** Specifies if the hardware definition exists on the server. */
-  int32 total_gpio_pins    = 2; /** Specifies the number of GPIO pins on the device. */
-  int32 total_analog_pins  = 3; /** Specifies the number of analog pins on the device. */
-  float reference_voltage  = 4; /** Specifies the hardware's default reference voltage. */
+  Response response                 = 1; /** Specifies if the hardware definition exists on the server. */
+  int32 total_gpio_pins             = 2; /** Specifies the number of GPIO pins on the device. */
+  int32 total_analog_pins           = 3; /** Specifies the number of analog pins on the device. */
+  float reference_voltage           = 4; /** Specifies the hardware's default reference voltage. */
+  ComponentAdds component_adds      = 5; /** A list of components to set up and initialize during checkin */
+  bool sleep_enabled                = 6; /** Whether sleep is enabled or not, ignore config if not */
+  ws.sleep.SleepConfig sleep_config = 7; /** Sleep configuration for the device */
 
-  repeated ComponentAdd component_adds = 5; /** A list of components to set up and initialize during checkin */
-  ws.sleep.Enter sleep                 = 6; /** Sleep configuration for the device */
   /**
    * Response. Specifies if the hardware definiton is within the database.
    */
@@ -66,17 +66,14 @@ message Response {
  * Generic component add message, could contain any *Add message from component protos
  */
 message ComponentAdd {
-  oneof payload {
-    ws.digitalio.Add digitalio    = 1;
-    ws.analogio.Add analogio      = 2;
-    ws.servo.Add servo            = 3;
-    ws.pwm.Add pwm                = 4;
-    ws.pixels.Add pixels          = 5;
-    ws.ds18x20.Add ds18x20        = 6;
-    ws.uart.Add uart              = 7;
-    ws.i2c.DeviceAddOrReplace i2c = 8;
-    ws.sleep.Enter sleep          = 9;
-  }
+  repeated ws.digitalio.Add digitalio    = 1;
+  repeated ws.analogio.Add analogio      = 2;
+  repeated ws.servo.Add servo            = 3;
+  repeated ws.pwm.Add pwm                = 4;
+  repeated ws.pixels.Add pixels          = 5;
+  repeated ws.ds18x20.Add ds18x20        = 6;
+  repeated ws.uart.Add uart              = 7;
+  repeated ws.i2c.DeviceAddOrReplace i2c = 8;
 }
 
 /**

--- a/proto/wippersnapper/checkin.proto
+++ b/proto/wippersnapper/checkin.proto
@@ -66,14 +66,14 @@ message Response {
  * Generic component add message, could contain any *Add message from component protos
  */
 message ComponentAdds {
-  repeated ws.digitalio.Add digitalioAdds    = 1;
-  repeated ws.analogio.Add analogioAdds      = 2;
-  repeated ws.servo.Add servoAdds            = 3;
-  repeated ws.pwm.Add pwmAdds                = 4;
-  repeated ws.pixels.Add pixelsAdds          = 5;
-  repeated ws.ds18x20.Add ds18x20Adds        = 6;
-  repeated ws.uart.Add uartAdds              = 7;
-  repeated ws.i2c.DeviceAddOrReplace i2cAdds = 8;
+  repeated ws.digitalio.Add digitalio_adds    = 1;
+  repeated ws.analogio.Add analogio_adds      = 2;
+  repeated ws.servo.Add servo_adds            = 3;
+  repeated ws.pwm.Add pwm_adds                = 4;
+  repeated ws.pixels.Add pixels_adds          = 5;
+  repeated ws.ds18x20.Add ds18x20_adds        = 6;
+  repeated ws.uart.Add uart_adds              = 7;
+  repeated ws.i2c.DeviceAddOrReplace i2c_adds = 8;
 }
 
 /**

--- a/proto/wippersnapper/checkin.proto
+++ b/proto/wippersnapper/checkin.proto
@@ -66,14 +66,14 @@ message Response {
  * Generic component add message, could contain any *Add message from component protos
  */
 message ComponentAdds {
-  repeated ws.digitalio.Add digitalio    = 1;
-  repeated ws.analogio.Add analogio      = 2;
-  repeated ws.servo.Add servo            = 3;
-  repeated ws.pwm.Add pwm                = 4;
-  repeated ws.pixels.Add pixels          = 5;
-  repeated ws.ds18x20.Add ds18x20        = 6;
-  repeated ws.uart.Add uart              = 7;
-  repeated ws.i2c.DeviceAddOrReplace i2c = 8;
+  repeated ws.digitalio.Add digitalioAdds    = 1;
+  repeated ws.analogio.Add analogioAdds      = 2;
+  repeated ws.servo.Add servoAdds            = 3;
+  repeated ws.pwm.Add pwmAdds                = 4;
+  repeated ws.pixels.Add pixelsAdds          = 5;
+  repeated ws.ds18x20.Add ds18x20Adds        = 6;
+  repeated ws.uart.Add uartAdds              = 7;
+  repeated ws.i2c.DeviceAddOrReplace i2cAdds = 8;
 }
 
 /**

--- a/proto/wippersnapper/sleep.proto
+++ b/proto/wippersnapper/sleep.proto
@@ -4,27 +4,6 @@ syntax = "proto3";
 package ws.sleep;
 
 /**
- * Wakeup (post-sleep) causes for ES32x chips.
- */
-enum EspWakeCause {
-  ESP_UNSPECIFIED     = 0;  /** In case of deep sleep, reset was not caused by exit from deep sleep. */
-  ESP_ALL             = 1;  /** Not a wakeup cause, used to disable all wakeup sources with esp_sleep_disable_wakeup_source. */
-  ESP_EXT0            = 2;  /** Wakeup caused by external signal using RTC_IO. */
-  ESP_EXT1            = 3;  /** Wakeup caused by external signal using RTC_CNTL. */
-  ESP_TIMER           = 4;  /** Wakeup caused by timer. */
-  ESP_TOUCHPAD        = 5;  /** Wakeup caused by touchpad. */
-  ESP_ULP             = 6;  /** Wakeup caused by ULP program. */
-  ESP_GPIO            = 7;  /** Wakeup caused by GPIO (light sleep only on ESP32, S2 and S3). */
-  ESP_UART            = 8;  /** Wakeup caused by UART (light sleep only). */
-  ESP_WIFI            = 9;  /** Wakeup caused by WIFI (light sleep only). */
-  ESP_COCPU           = 10; /** Wakeup caused by  COCPU int. */
-  ESP_COCPU_TRAP      = 11; /** Wakeup caused by COCPU crash. */
-  ESP_BT              = 12; /** Wakeup caused by BT (light sleep only). */
-  ESP_VAD             = 13; /** Wakeup caused by VAD. */
-  ESP_VBAT_UNDER_VOLT = 14; /** Wakeup caused by VDD_BAT under voltage. */
-}
-
-/**
  * Device sleep modes
  */
 enum SleepMode {
@@ -38,7 +17,7 @@ enum SleepMode {
  */
 message B2D {
   oneof payload {
-    Enter enter = 1; /** Message containing required information to enter deep sleep. */
+    SleepConfig sleep_config = 1; /** Message containing required information to enter deep sleep. */
   }
 }
 
@@ -48,7 +27,6 @@ message B2D {
 message D2B {
   oneof payload {
     Goodnight goodnight = 1; /** Goodnight event. */
-    Wake      wake = 2; /** Wakeup event. */
   }
 }
 
@@ -57,16 +35,6 @@ message D2B {
  */
 message Goodnight {
   string message = 1; /** Message indicating the device is going to sleep. */
-}
-
-/**
- * Wakeup event message from the device.
- */
-message Wake {
-  oneof WakeCause {
-    EspWakeCause esp    = 1; /** Wakeup cause for ESP32x MCUs. */
-  }
-  uint32 sleep_duration = 2; /** Calculated duration of the sleep duration, in seconds. */
 }
 
 /**
@@ -80,19 +48,18 @@ message TimerConfig {
  * Pin configuration for ext0 RTC wakeup source.
  */
 message Ext0Config {
-  string name = 1; /** Pin to wake up from. */
-  bool level  = 2; /**  Input level which will trigger wakeup (False = low, True = high) */
-  bool pull   = 3; /**  Enable internal pull-up or pull-down resistors */
+  string pin_name = 1; /** Pin to wake up from. */
+  bool level      = 2; /** Input level which will trigger wakeup (False = low, True = high) */
+  bool pull       = 3; /** Enable internal pull-up or pull-down resistors */
 }
 
 /**
  * Contains configuration to enter a sleep mode.
  */
-message Enter {
-  bool lock           = 1; /** Tells the device if it is entering sleep or not. */
-  SleepMode mode      = 2; /** Sleep mode. */
+message SleepConfig {
+  SleepMode mode      = 1; /** Sleep mode. */
   oneof config {
-    TimerConfig timer = 3; /** Timer configuration for wakeup source. */
-    Ext0Config ext0   = 4; /** EXT0 RTC configuration for wakeup source. */
+    TimerConfig timer = 2; /** Timer configuration for wakeup source. */
+    Ext0Config ext0   = 3; /** EXT0 RTC configuration for wakeup source. */
   }
 }


### PR DESCRIPTION
Sleep:
- drop wake cause/duration altogether for now
- rename `Enter` -> `SleepConfig`

Checkin:
- instead of `repeated ComponentAdd` message holding a `oneof` for every component
- optional `ComponentAdds` with `repeated` fields for each component type
In the former case, every `ComponentAdd` was sized to the largest component it might contain, which is GPS, which is kilobytes, while most components are mere bytes. In the latter case, the component-type-specific arrays are sized appropriately, and take no space when empty.