### PR TITLE
tidy, drop i2c output and datalogging, bus/mux clarity

### DIFF
--- a/proto/wippersnapper/i2c.options
+++ b/proto/wippersnapper/i2c.options
@@ -1,9 +1,5 @@
 # i2c.options
-ws.i2c.Scanned.bus_found_devices           max_count:120
+ws.i2c.Scanned.found_devices           max_count:120
 ws.i2c.DeviceAddOrReplace.device_name         max_size:15
 ws.i2c.DeviceAddOrReplace.device_sensor_types max_count:15
 ws.i2c.DeviceEvent.device_events              max_count:15
-ws.i2c.DeviceDescriptor.bus_sda               max_size:15
-ws.i2c.DeviceDescriptor.bus_scl               max_size:15
-ws.i2c.BusDescriptor.bus_sda                  max_size:15
-ws.i2c.BusDescriptor.bus_scl                  max_size:15

--- a/proto/wippersnapper/i2c.options
+++ b/proto/wippersnapper/i2c.options
@@ -1,5 +1,5 @@
 # i2c.options
-ws.i2c.BusScanned.bus_found_devices           max_count:120
+ws.i2c.Scanned.bus_found_devices           max_count:120
 ws.i2c.DeviceAddOrReplace.device_name         max_size:15
 ws.i2c.DeviceAddOrReplace.device_sensor_types max_count:15
 ws.i2c.DeviceEvent.device_events              max_count:15

--- a/proto/wippersnapper/i2c.proto
+++ b/proto/wippersnapper/i2c.proto
@@ -69,6 +69,9 @@ message DeviceDescriptor {
 message Scan {
   ScanTarget target = 1; /** Which bus or mux to scan **/
 
+  /**
+  * ScanTarget represents which bus or mux to scan for I2C devices.
+  */
   enum ScanTarget {
     ST_UNSPECIFIED = 0; /** Unspecified target, should not happen **/
     ST_BUS         = 1; /** Scan the default bus **/

--- a/proto/wippersnapper/i2c.proto
+++ b/proto/wippersnapper/i2c.proto
@@ -58,42 +58,35 @@ enum DeviceStatus {
 * DeviceDescriptor represents the I2c device's address and related metadata.
 */
 message DeviceDescriptor {
-  string bus_sda        = 1; /** Optional SDA pin for an alt. i2c bus.**/
-  string bus_scl        = 2; /** Optional SCL pin for an alt. i2c bus.**/
-  uint32 device_address = 3; /** I2C Device's Address. **/
-  uint32 mux_address    = 4; /** Optional I2C multiplexer address. **/
-  uint32 mux_channel    = 5; /** Optional I2C multiplexer channel. **/
-}
-
-/**
-* BusDescriptor represents the I2c bus' SDA and SCL pins.
-*/
-message BusDescriptor {
-  string bus_sda = 1; /** SDA pin for an i2c bus.**/
-  string bus_scl = 2; /** SCL pin for an i2c bus.**/
+  bool alt_bus          = 1; /** On the alternate bus? **/
+  uint32 device_address = 2; /** Device's i2c address, on either the bus or the mux **/
+  uint32 mux_address    = 3; /** Optional - I2C multiplexer address. **/
+  uint32 mux_channel    = 4; /** Optional - I2C multiplexer channel. **/
 }
 
 /**
 * BusScan represents a command for a device to perform an i2c scan.
 */
-message BusScan {
-  bool scan_default_bus            = 1; /** Default - Scan for i2c devices on the hardware's default I2C bus.**/
-  bool scan_alt_bus                = 2; /** Optional - Scan for i2c devices on an alternative I2C bus.**/
-  BusDescriptor alt_bus_descriptor = 3; /** Optional - Metadata to optionally initialize (if not already init'd) an alt. i2c bus.**/
-  bool scan_default_bus_mux        = 4; /** Optional - Scan for i2c devices on the default I2C bus with a multiplexer.**/
-  bool scan_alt_bus_mux            = 5; /** Optional - Scan for i2c devices on an alternative I2C bus with a multiplexer.**/
+message Scan {
+  ScanTarget target = 1; /** Which bus or mux to scan **/
+
+  enum ScanTarget {
+    ST_UNSPECIFIED = 0; /** Unspecified target, should not happen **/
+    ST_BUS         = 1; /** Scan the default bus **/
+    ST_ALT_BUS     = 2; /** Scan the alternate bus **/
+    ST_BUS_MUX     = 3; /** Scan the mux on the default bus **/
+    ST_ALT_BUS_MUX = 4; /** Scan the mux on the alternate bus **/
+  }
 }
 
 /**
-* BusScanned represents a list of I2c addresses
-* found on the bus after Scan has executed.
+* Scanned represents a list of I2c addresses on a bus and optionally a mux,
+* found after Scan has executed.
 */
-message BusScanned {
-  repeated DeviceDescriptor bus_found_devices = 1; /** The 7-bit addresses of the I2c devices found on the bus, empty if not found. */
-  BusStatus bus_status                        = 2; /** The I2c bus' status. **/
+message Scanned {
+  repeated DeviceDescriptor found_devices = 1; /** List of the I2c device addresses found, with bus and mux info. */
+  BusStatus bus_status                        = 2; /** The I2c bus' status, in case of bus error. **/
 }
-
-// DEVICE COMMANDS
 
 /**
 * DeviceAddOrReplace is a message for initializing (or replacing/updating) an i2c device.
@@ -104,20 +97,16 @@ message DeviceAddOrReplace {
                                                        https://github.com/adafruit/Wippersnapper_Components. */
   float device_period                         = 3; /** The desired period to update the I2c device's sensor(s), in seconds. */
   repeated ws.sensor.Type device_sensor_types = 4; /** SI Types for each sensor on the I2c device. */
-  bool is_persistent                          = 5; /** Offline-Mode ONLY - True if the device exits in the config file, False otherwise. **/
-  bool is_output                              = 6; /** Required by the device to determine if the component is an output.**/
-  ws.i2c_output.Add output_add                = 7; /** Optional - If the I2C device is an output device, fill this field. **/
-  bool is_gps                                 = 8; /** Required by the device to determine if the component is a GPS.**/
-  ws.gps.Config gps_config                    = 9; /** Optional - If the I2C device is a GPS driver, fill this field with the GPS config. **/
+  ws.gps.Config gps_config                    = 5; /** Optional - If the I2C device is a GPS driver, fill this field with the GPS config. **/
 }
 
 /**
 * DeviceAddedOrReplaced contains the response from a device after processing a DeviceAddOrReplace message.
 */
 message DeviceAddedOrReplaced {
-  DeviceDescriptor device_description = 1; /** The I2c device's address and metadata. */
-  BusStatus bus_status                = 2; /** The I2c bus' status. **/
-  DeviceStatus device_status          = 3; /** The I2c device's status. **/
+  DeviceDescriptor device_description = 1; /** The I2c device's address and metadata, unless there was an error. **/
+  BusStatus bus_status                = 2; /** The I2c bus' status, in case of bus error. **/
+  DeviceStatus device_status          = 3; /** The I2c device's status, in case of device error. **/
 }
 
 /**
@@ -125,7 +114,6 @@ message DeviceAddedOrReplaced {
 */
 message DeviceRemove {
   DeviceDescriptor device_description = 1; /** The I2c device's address and metadata. */
-  bool is_output_device               = 2; /** Determines if the device is an output device.**/
 }
 
 /**
@@ -137,23 +125,10 @@ message DeviceRemoved {
 }
 
 /**
-* Each DeviceEvent represents data from **one** I2c sensor.
-* NOTE: An DeviceEvent can have multiple sensor events if
-* the I2c device contains > 1 sensor.
+* Each DeviceEvent represents data from **one** I2C device, containing one or more sensors.
 */
 message DeviceEvent {
   DeviceDescriptor device_description    = 1; /** The I2c device's address and metadata. */
-  repeated ws.sensor.Event device_events = 2; /** Required, but optionally repeated, SensorEvent from a sensor. */
+  repeated ws.sensor.Event device_events = 2; /** An event from each of the device's configured sensors. */
 }
 
-/**
-* DeviceOutputWrite represents a request to write to an I2C output device.
-*/
-message DeviceOutputWrite {
-  DeviceDescriptor device_description                 = 1; /** Required - The I2c device's address and metadata. */
-  oneof output_msg {
-    ws.i2c_output.LedBackpackWrite write_led_backpack = 2; /** Optional - If the I2C device is a LED backpack, fill this field. **/
-    ws.i2c_output.CharLCDWrite write_char_lcd         = 3; /** Optional - If the I2C device is a character LCD, fill this field. **/
-    ws.i2c_output.OLEDWrite write_oled                = 4; /** Optional - If the I2C device is an OLED display, fill this field. **/
-  }
-}

--- a/proto/wippersnapper/i2c.proto
+++ b/proto/wippersnapper/i2c.proto
@@ -11,10 +11,9 @@ import "sensor.proto";
  */
 message B2D {
   oneof payload {
-    BusScan bus_scan                      = 1;
+    Scan bus_scan                      = 1;
     DeviceAddOrReplace device_add_replace = 2;
     DeviceRemove device_remove            = 3;
-    DeviceOutputWrite device_output_write = 4;
   }
 }
 
@@ -23,7 +22,7 @@ message B2D {
  */
 message D2B {
   oneof payload {
-    BusScanned bus_scanned                      = 1;
+    Scanned bus_scanned                      = 1;
     DeviceAddedOrReplaced device_added_replaced = 2;
     DeviceRemoved device_removed                = 3;
     DeviceEvent device_event                    = 4;
@@ -65,7 +64,7 @@ message DeviceDescriptor {
 }
 
 /**
-* BusScan represents a command for a device to perform an i2c scan.
+* Scan represents a command for a device to perform an i2c scan.
 */
 message Scan {
   ScanTarget target = 1; /** Which bus or mux to scan **/


### PR DESCRIPTION
Chatted with Brent about I2C, reified the things we discussed (and some we didn't) in this PR.

Also note i pulled `Bus...` off the front of `BusScan` since it could be a mux scan now as well.