### PR TITLE
Remove predefined bus, support N I2C buses

### DIFF
--- a/proto/wippersnapper/i2c.options
+++ b/proto/wippersnapper/i2c.options
@@ -1,5 +1,5 @@
 # i2c.options
-ws.i2c.Scanned.found_devices           max_count:120
-ws.i2c.DeviceAddOrReplace.device_name         max_size:15
-ws.i2c.DeviceAddOrReplace.device_sensor_types max_count:15
-ws.i2c.DeviceEvent.device_events              max_count:15
+ws.i2c.Scanned.found_devices                  max_count:112
+ws.i2c.DeviceAddOrReplace.device_name         max_size:16
+ws.i2c.DeviceAddOrReplace.device_sensor_types max_count:16
+ws.i2c.DeviceEvent.device_events              max_count:16

--- a/proto/wippersnapper/i2c.options
+++ b/proto/wippersnapper/i2c.options
@@ -1,5 +1,5 @@
 # i2c.options
-ws.i2c.Scanned.found_devices                  max_count:112
+ws.i2c.Scanned.found_devices                  max_count:16
 ws.i2c.DeviceAddOrReplace.device_name         max_size:16
 ws.i2c.DeviceAddOrReplace.device_sensor_types max_count:16
 ws.i2c.DeviceEvent.device_events              max_count:16

--- a/proto/wippersnapper/i2c.proto
+++ b/proto/wippersnapper/i2c.proto
@@ -57,28 +57,20 @@ enum DeviceStatus {
 * DeviceDescriptor represents the I2c device's address and related metadata.
 */
 message DeviceDescriptor {
-  bool alt_bus          = 1; /** On the alternate bus? **/
-  uint32 device_address = 2; /** Device's i2c address, on either the bus or the mux **/
-  uint32 mux_address    = 3; /** Optional - I2C multiplexer address. **/
-  uint32 mux_channel    = 4; /** Optional - I2C multiplexer channel. **/
+  string pin_scl        = 1; /** Pin name for the I2C SCL line **/
+  string pin_sda        = 2; /** Pin name for the I2C SDA line **/
+  uint32 device_address = 3; /** Device's i2c address, either on the bus or the mux **/
+  uint32 mux_address    = 4; /** Optional - I2C multiplexer address. **/
+  uint32 mux_channel    = 5; /** Optional - I2C multiplexer channel. **/
 }
 
 /**
 * Scan represents a command for a device to perform an i2c scan.
 */
 message Scan {
-  ScanTarget target = 1; /** Which bus or mux to scan **/
-
-  /**
-  * ScanTarget represents which bus or mux to scan for I2C devices.
-  */
-  enum ScanTarget {
-    ST_UNSPECIFIED = 0; /** Unspecified target, should not happen **/
-    ST_BUS         = 1; /** Scan the default bus **/
-    ST_ALT_BUS     = 2; /** Scan the alternate bus **/
-    ST_BUS_MUX     = 3; /** Scan the mux on the default bus **/
-    ST_ALT_BUS_MUX = 4; /** Scan the mux on the alternate bus **/
-  }
+  string pin_scl     = 1; /** Pin name for the I2C SCL line **/
+  string pin_sda     = 2; /** Pin name for the I2C SDA line **/
+  uint32 mux_address = 3; /** Optional - I2C multiplexer address to scan. **/
 }
 
 /**


### PR DESCRIPTION
Removes support for 2 predefined I2C buses, adds support for `N` buses via the inclusion of fields `pin_scl` and `pin_sda`. 

Scan now contains the pin definitions and an optional i2c mux address (scl/sda/mux addr. must be set to scan across a mux).