### PR TITLE
Refactor around gps.proto

### DIFF
--- a/proto/wippersnapper/gps.proto
+++ b/proto/wippersnapper/gps.proto
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: MIT
 syntax = "proto3";
 package ws.gps;
-import "i2c.proto"
-import "uart.proto"
+import "i2c.proto";
+import "uart.proto";
 
 // Note: GPSB2D does not exist as
 // GPSConfig is sent as a submessage

--- a/proto/wippersnapper/gps.proto
+++ b/proto/wippersnapper/gps.proto
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: MIT
 syntax = "proto3";
 package ws.gps;
+import "i2c.proto"
+import "uart.proto"
 
 // Note: GPSB2D does not exist as
 // GPSConfig is sent as a submessage
@@ -12,8 +14,27 @@ package ws.gps;
  */
 message D2B {
   oneof payload {
-    Event event = 10;
+    Event event = 1;
   }
+}
+
+/**
+ * BrokerToDevice message envelope
+ */
+message B2D {
+  oneof payload {
+    DeviceAddOrReplace device_add_replace = 1;
+    DeviceRemove device_remove            = 2;
+  }
+}
+
+/**
+ * DeviceAddOrReplace message
+ */
+message DeviceAddOrReplace {
+  i2c.DeviceAddedOrReplaced add_i2c  = 1;
+  uart.Add                  add_uart = 2;
+  Config                    config   = 3;
 }
 
 /**

--- a/proto/wippersnapper/gps.proto
+++ b/proto/wippersnapper/gps.proto
@@ -29,12 +29,20 @@ message B2D {
 }
 
 /**
- * DeviceAddOrReplace message
+ * AddOrReplace message
  */
 message DeviceAddOrReplace {
   i2c.DeviceAddedOrReplaced add_i2c  = 1;
   uart.Add                  add_uart = 2;
   Config                    config   = 3;
+}
+
+/**
+ * Remove message
+ */
+message DeviceRemove {
+  i2c.DeviceRemove remove_i2c  = 1;
+  uart.Remove      remove_uart = 2;
 }
 
 /**

--- a/proto/wippersnapper/i2c.proto
+++ b/proto/wippersnapper/i2c.proto
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: MIT
 syntax = "proto3";
 package ws.i2c;
-import "gps.proto";
 import "sensor.proto";
 
 /**
@@ -90,7 +89,6 @@ message DeviceAddOrReplace {
                                                        https://github.com/adafruit/Wippersnapper_Components. */
   float device_period                         = 3; /** The desired period to update the I2c device's sensor(s), in seconds. */
   repeated ws.sensor.Type device_sensor_types = 4; /** SI Types for each sensor on the I2c device. */
-  ws.gps.Config gps_config                    = 5; /** Optional - If the I2C device is a GPS driver, fill this field with the GPS config. **/
 }
 
 /**

--- a/proto/wippersnapper/signal.proto
+++ b/proto/wippersnapper/signal.proto
@@ -39,6 +39,7 @@ message BrokerToDevice {
     ws.ds18x20.B2D ds18x20     = 35;
     ws.uart.B2D uart           = 36;
     ws.i2c.B2D i2c             = 37;
+    ws.gps.B2D gps             = 38;
   }
 }
 

--- a/proto/wippersnapper/uart.proto
+++ b/proto/wippersnapper/uart.proto
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: MIT
 syntax = "proto3";
 package ws.uart;
-import "gps.proto";
 import "sensor.proto";
 
 /**
@@ -140,7 +139,6 @@ message DeviceConfig {
     GenericInputConfig generic_input           = 3; /** OPTIONAL configuration for a generic UART input device. */
     TrinamicDynamixelConfig trinamic_dynamixel = 4; /** OPTIONAL configuration for a Trinamic stepper or DYNAMIXEL servo. */
     PM25AQIConfig pm25aqi                      = 5; /** OPTIONAL configuration for a PM2.5 AQI sensor. */
-    ws.gps.Config gps                          = 6; /** OPTIONAL configuration for a GPS RMC response. */
   }
 }
 


### PR DESCRIPTION
The intent of this PR is to declare `GPS.proto` as a top-level interface, and have the transport interfaces (`uart.proto`, `i2c.proto`) within it. The overarching idea is that the GPS B2D messages contain all details required to add a GPS device, rather than the _interface_ containing details about the GPS device.

It also removes critical a circular dependency problem where GPS and I2c/UART would both need to `import` each other. @tyeth already ran into on `display.proto`. 