### PR TITLE
Expander API

### DIFF
--- a/proto/wippersnapper/expander.proto
+++ b/proto/wippersnapper/expander.proto
@@ -29,26 +29,26 @@ message D2B {
 * Add adds an expander to the hardware.
 */
 message Add {
-  i2c.DeviceAddOrReplace cfg = 1; /** I2C configuration for the expander. */
+  i2c.DeviceAddOrReplace cfg_i2c = 1; /** I2C configuration for the expander. */
 }
 
 /**
 * Added represents a message from the hardware indicating an expander was added.
 */
 message Added {
-  i2c.DeviceAddedOrReplaced response = 1; /** I2C configuration response. */
+  i2c.DeviceAddedOrReplaced response_i2c = 1; /** I2C configuration response. */
 }
 
 /**
 * Remove removes an analog pin from the hardware.
 */
 message Remove {
-  i2c.DeviceRemove cfg = 1; /** I2C configuration for the expander to remove. */
+  i2c.DeviceRemove cfg_i2c = 1; /** I2C configuration for the expander to remove. */
 }
 
 /**
 * Removed represents a message from the device indicating an expander was removed.
 */
 message Removed {
-  i2c.DeviceRemoved response = 1; /** I2C configuration response. */
+  i2c.DeviceRemoved response_i2c = 1; /** I2C configuration response. */
 }

--- a/proto/wippersnapper/expander.proto
+++ b/proto/wippersnapper/expander.proto
@@ -3,7 +3,6 @@
 syntax = "proto3";
 package ws.expander;
 import "i2c.proto";
-import "digitalio.proto";
 
 /**
  * BrokerToDevice message envelope

--- a/proto/wippersnapper/expander.proto
+++ b/proto/wippersnapper/expander.proto
@@ -1,0 +1,54 @@
+// SPDX-FileCopyrightText: 2026 Brent Rubell for Adafruit Industries
+// SPDX-License-Identifier: MIT
+syntax = "proto3";
+package ws.expander;
+import "i2c.proto";
+import "digitalio.proto";
+
+/**
+ * BrokerToDevice message envelope
+ */
+message B2D {
+  oneof payload {
+    Add add       = 1;
+    Remove remove = 2;
+  }
+}
+
+/**
+ DeviceToBroker message envelope
+ */
+message D2B {
+  oneof payload {
+    Added added     = 1;
+    Removed removed = 2;
+  }
+}
+
+/**
+* Add adds an expander to the hardware.
+*/
+message Add {
+  i2c.DeviceAddOrReplace cfg = 1; /** I2C configuration for the expander. */
+}
+
+/**
+* Added represents a message from the hardware indicating an expander was added.
+*/
+message Added {
+  i2c.DeviceAddedOrReplaced response = 1; /** I2C configuration response. */
+}
+
+/**
+* Remove removes an analog pin from the hardware.
+*/
+message Remove {
+  i2c.DeviceRemove cfg = 1; /** I2C configuration for the expander to remove. */
+}
+
+/**
+* Removed represents a message from the device indicating an expander was removed.
+*/
+message Removed {
+  i2c.DeviceRemoved response = 1; /** I2C configuration response. */
+}

--- a/proto/wippersnapper/signal.proto
+++ b/proto/wippersnapper/signal.proto
@@ -3,6 +3,7 @@
 syntax = "proto3";
 package ws.signal;
 import "error.proto";
+import "expander.proto";
 import "checkin.proto";
 import "analogio.proto";
 import "digitalio.proto";
@@ -42,6 +43,7 @@ message BrokerToDevice {
     ws.uart.B2D uart           = 37;
     ws.i2c.B2D i2c             = 38;
     ws.gps.B2D gps             = 39;
+    ws.expander.B2D expander   = 40;
   }
 }
 
@@ -71,5 +73,6 @@ message DeviceToBroker {
     ws.uart.D2B uart           = 37;
     ws.i2c.D2B i2c             = 38;
     ws.gps.D2B gps             = 39;
+    ws.expander.D2B expander   = 40;
   }
 }


### PR DESCRIPTION
This pull request introduces a new protocol buffer definition for supporting I2C expander devices and integrates it into the main WipperSnapper signaling protocol. 

**Related**:
* Arduino PR: TBD!
* Boards PR: https://github.com/adafruit/Wippersnapper_Boards/pull/246
* Component PR: https://github.com/adafruit/Wippersnapper_Components/pull/320

