### PR TITLE
Add - Probe API

### DIFF
--- a/proto/wippersnapper/i2c.options
+++ b/proto/wippersnapper/i2c.options
@@ -3,3 +3,4 @@ ws.i2c.Scanned.found_devices                  max_count:16
 ws.i2c.DeviceAddOrReplace.device_name         max_size:16
 ws.i2c.DeviceAddOrReplace.device_sensor_types max_count:16
 ws.i2c.DeviceEvent.device_events              max_count:16
+ws.i2c.Probe.device_addresses                 max_count:16

--- a/proto/wippersnapper/i2c.options
+++ b/proto/wippersnapper/i2c.options
@@ -1,5 +1,5 @@
 # i2c.options
-ws.i2c.Scanned.found_devices                  max_count:16
+ws.i2c.Results.found_devices                  max_count:16
 ws.i2c.DeviceAddOrReplace.device_name         max_size:16
 ws.i2c.DeviceAddOrReplace.device_sensor_types max_count:16
 ws.i2c.DeviceEvent.device_events              max_count:16

--- a/proto/wippersnapper/i2c.proto
+++ b/proto/wippersnapper/i2c.proto
@@ -21,11 +21,10 @@ message B2D {
  */
 message D2B {
   oneof payload {
-    Scanned bus_scanned                         = 1;
+    Results bus_scanned                         = 1;
     DeviceAddedOrReplaced device_added_replaced = 2;
     DeviceRemoved device_removed                = 3;
     DeviceEvent device_event                    = 4;
-    Probed device_probed                        = 5;
   }
 }
 
@@ -74,10 +73,10 @@ message Scan {
 }
 
 /**
-* Scanned represents a list of I2c addresses on a bus and optionally a mux,
+* Results represents a list of I2c addresses on a bus and optionally a mux,
 * found after Scan has executed.
 */
-message Scanned {
+message Results {
   repeated DeviceDescriptor found_devices = 1; /** List of the I2c device addresses found, with bus and mux info. */
   BusStatus bus_status                    = 2; /** The I2c bus' status, in case of bus error. **/
 }
@@ -91,14 +90,6 @@ message Probe {
   uint32 pin_sda                   = 2; /** Desired I2C bus' SDA pin. **/
   repeated uint32 device_addresses = 3; /** List of I2c device addresses to probe on the bus. **/
 }
-
-/**
-* Probed represents the response from a device after processing a Probe message.
-*/
-message Probed {
-  Scanned devices = 1; /** List of the I2c device addresses found from the probe, with bus and mux info. **/
-}
-
 
 /**
 * DeviceAddOrReplace is a message for initializing (or replacing/updating) an i2c device.

--- a/proto/wippersnapper/i2c.proto
+++ b/proto/wippersnapper/i2c.proto
@@ -9,9 +9,10 @@ import "sensor.proto";
  */
 message B2D {
   oneof payload {
-    Scan bus_scan                      = 1;
+    Scan bus_scan                         = 1;
     DeviceAddOrReplace device_add_replace = 2;
     DeviceRemove device_remove            = 3;
+    Probe device_probe                    = 4;
   }
 }
 
@@ -20,10 +21,11 @@ message B2D {
  */
 message D2B {
   oneof payload {
-    Scanned bus_scanned                      = 1;
+    Scanned bus_scanned                         = 1;
     DeviceAddedOrReplaced device_added_replaced = 2;
     DeviceRemoved device_removed                = 3;
     DeviceEvent device_event                    = 4;
+    Probed device_probed                        = 5;
   }
 }
 
@@ -77,8 +79,26 @@ message Scan {
 */
 message Scanned {
   repeated DeviceDescriptor found_devices = 1; /** List of the I2c device addresses found, with bus and mux info. */
-  BusStatus bus_status                        = 2; /** The I2c bus' status, in case of bus error. **/
+  BusStatus bus_status                    = 2; /** The I2c bus' status, in case of bus error. **/
 }
+
+/**
+* Probe represents a command for a device to check for the presence of a specific i2c device on a bus.
+* NOTE: This message allows multiple device addresses to be probed, which is useful for i2c devices with multiple potential addresses.
+*/
+message Probe {
+  uint32 pin_scl                   = 1; /** Desired I2C bus' SCL pin. **/
+  uint32 pin_sda                   = 2; /** Desired I2C bus' SDA pin. **/
+  repeated uint32 device_addresses = 3; /** List of I2c device addresses to probe on the bus. **/
+}
+
+/**
+* Probed represents the response from a device after processing a Probe message.
+*/
+message Probed {
+  Scanned devices = 1; /** List of the I2c device addresses found from the probe, with bus and mux info. **/
+}
+
 
 /**
 * DeviceAddOrReplace is a message for initializing (or replacing/updating) an i2c device.


### PR DESCRIPTION
This pull request adds two new message types:
* `Probe` - A message for a device to check for the presence of a specific i2c device on a bus. This message allows multiple device addresses to be probed, which is useful for i2c devices with multiple potential addresses.
* `Probed` - A wrapper message around `Scanned`. This is to align with the `.proto`'s naming convention, the Python client expects a request/response type pattern, and we have already proved out the `Scanned` path (reuse).


I also did some whitespace cleanup, unrelated and should not affect functionality.