### PR TITLE
20260429 remove display options

### DIFF
--- a/proto/wippersnapper/display.options
+++ b/proto/wippersnapper/display.options
@@ -45,9 +45,3 @@ ws.display.BacklightConfig.pin                   max_size:6
 
 # Write message
 ws.display.Write.message                        max_size:1024
-
-# Write message defaults
-# clear_first: proto3 defaults bool to false, use initializer to override init macros
-ws.display.Write.clear_first                    initializer:"true"
-# cursor_x/cursor_y default to 0 already in proto3, no override needed
-

--- a/proto/wippersnapper/display.options
+++ b/proto/wippersnapper/display.options
@@ -1,10 +1,13 @@
 # display.options
 # Nanopb configuration for display.proto
 
+# B2D/D2B envelopes
+ws.display.B2D.name                             max_size:64
+ws.display.D2B.name                             max_size:64
+
 # Add message
 ws.display.Add.driver                           max_size:32
 ws.display.Add.panel                            max_size:32
-ws.display.Add.name                             max_size:64
 
 # Display-specific SPI pin constraints (shared SPI pins are in spi.options)
 ws.display.TftSpiConfig.pin_dc                  max_size:6
@@ -40,22 +43,11 @@ ws.display.DsiInterfaceConfig.pin_rst            max_size:6
 
 ws.display.BacklightConfig.pin                   max_size:6
 
-# Remove message
-ws.display.Remove.name                          max_size:64
-
 # Write message
-ws.display.Write.name                           max_size:64
 ws.display.Write.message                        max_size:1024
-# Large content fields use callbacks to avoid static allocation on embedded
-ws.display.Write.url                            type:FT_CALLBACK
-ws.display.Write.base64image                    type:FT_CALLBACK
-ws.display.Write.binary_image                   type:FT_CALLBACK
 
 # Write message defaults
 # clear_first: proto3 defaults bool to false, use initializer to override init macros
 ws.display.Write.clear_first                    initializer:"true"
 # cursor_x/cursor_y default to 0 already in proto3, no override needed
 
-# Response messages
-ws.display.AddedOrReplaced.name                 max_size:64
-ws.display.Removed.name                         max_size:64


### PR DESCRIPTION
Not quite sure what I'm doing with the name element. It was at the envelope level (D2B/B2D), but that's skipped when displayAdd messages and displayWrite are nested (displayAdd part of checkinResponse/componentsAdd, or displayWrite as part of displayAdd).

For now the display is written to and removed by name, which needs cementing.