### PR TITLE
Increase max_size in pwm.proto

### DIFF
--- a/proto/wippersnapper/pwm.options
+++ b/proto/wippersnapper/pwm.options
@@ -1,5 +1,5 @@
 # pwm.options
-ws.pwm.Add.pin    max_size:64
-ws.pwm.Added.pin  max_size:64
-ws.pwm.Remove.pin max_size:64
-ws.pwm.Write.pin  max_size:64
+ws.pwm.Add.pin    max_size:16
+ws.pwm.Added.pin  max_size:16
+ws.pwm.Remove.pin max_size:16
+ws.pwm.Write.pin  max_size:16

--- a/proto/wippersnapper/pwm.options
+++ b/proto/wippersnapper/pwm.options
@@ -1,5 +1,5 @@
 # pwm.options
-ws.pwm.Add.pin    max_size:6
-ws.pwm.Added.pin  max_size:6
-ws.pwm.Remove.pin max_size:6
-ws.pwm.Write.pin  max_size:6
+ws.pwm.Add.pin    max_size:64
+ws.pwm.Added.pin  max_size:64
+ws.pwm.Remove.pin max_size:64
+ws.pwm.Write.pin  max_size:64


### PR DESCRIPTION
Expander pins take the form `EXP_{I2c_Address}_Pin#`. The `max_size` field for a PWM pin is 6 characters, too small for the component API to support expanders.

This pull request aims to match the size for the `pin` field used by `pwm.proto` with `digitalio.options` and `analogio.options`.