### PR TITLE
use map protobuf type

### DIFF
--- a/proto/wippersnapper/checkin.proto
+++ b/proto/wippersnapper/checkin.proto
@@ -74,7 +74,7 @@ message ComponentAdds {
   repeated ws.pixels.Add pixels_adds          = 5;
   repeated ws.ds18x20.Add ds18x20_adds        = 6;
   repeated ws.uart.Add uart_adds              = 7;
-  repeated ws.i2c.DeviceAddOrReplace i2c_adds = 8;
+  repeated ws.i2c.Add i2c_adds                = 8;
   repeated ws.display.Add display_adds        = 9;
 }
 

--- a/proto/wippersnapper/display.proto
+++ b/proto/wippersnapper/display.proto
@@ -222,7 +222,7 @@ message Add {
   oneof interface_type {
     EpdSpiConfig spi_epd          = 5; /** SPI configuration for EPD. */
     TftSpiConfig spi_tft          = 6; /** SPI configuration for TFT. */
-    ws.i2c.DeviceDescriptor i2c   = 7; /** I2C configuration for OLED/LED/LCD displays. */
+    ws.i2c.Descriptor i2c         = 7; /** I2C configuration for OLED/LED/LCD displays. */
     TtlRgb666PinConfig ttl_rgb666 = 8; /** RGB666 configuration for Qualia. */
     I8080PinConfig i8080          = 9; /** i8080 8-bit parallel for T-DisplayS3/Memento. */
     DsiInterfaceConfig dsi        = 10; /** DSI configuration for MIPI DSI displays (e.g., ESP32-P4). */

--- a/proto/wippersnapper/ds18x20.options
+++ b/proto/wippersnapper/ds18x20.options
@@ -1,7 +1,7 @@
 # ds18x20.options
-ws.ds18x20.Add.onewire_pin      max_size:5
-ws.ds18x20.Added.onewire_pin    max_size:5
-ws.ds18x20.Remove.onewire_pin   max_size:5
-ws.ds18x20.Event.onewire_pin    max_size:5
-ws.ds18x20.Add.sensor_types     max_count:2
-ws.ds18x20.Event.sensor_events  max_count:2
+ws.ds18x20.Add.onewire_pin    max_size:5
+ws.ds18x20.Added.onewire_pin  max_size:5
+ws.ds18x20.Remove.onewire_pin max_size:5
+ws.ds18x20.Event.onewire_pin  max_size:5
+ws.ds18x20.Add.sensors        max_count:2
+ws.ds18x20.Event.events       max_count:2

--- a/proto/wippersnapper/ds18x20.options
+++ b/proto/wippersnapper/ds18x20.options
@@ -3,5 +3,5 @@ ws.ds18x20.Add.onewire_pin    max_size:5
 ws.ds18x20.Added.onewire_pin  max_size:5
 ws.ds18x20.Remove.onewire_pin max_size:5
 ws.ds18x20.Event.onewire_pin  max_size:5
-ws.ds18x20.Add.sensors        max_count:2
+ws.ds18x20.Add.types          max_count:2
 ws.ds18x20.Event.events       max_count:2

--- a/proto/wippersnapper/ds18x20.proto
+++ b/proto/wippersnapper/ds18x20.proto
@@ -31,10 +31,10 @@ message D2B {
 * NOTE: This API currently only supports ONE device per OneWire bus.
 */
 message Add {
-  string onewire_pin              = 1; /** The desired pin to use as a OneWire bus. */
-  int32 sensor_resolution         = 2; /** The desired sensor resolution (9, 10, 11, or 12 bits). */
-  float period                    = 3; /** The desired period to read the sensor, in seconds. */
-  repeated ws.sensor.Type sensors = 4; /** SI types used by the DS18x20 sensor. */
+  string onewire_pin            = 1; /** The desired pin to use as a OneWire bus. */
+  int32 sensor_resolution       = 2; /** The desired sensor resolution (9, 10, 11, or 12 bits). */
+  float period                  = 3; /** The desired period to read the sensor, in seconds. */
+  repeated ws.sensor.Type types = 4; /** SI types used by the DS18x20 sensor. */
 }
 
 /**

--- a/proto/wippersnapper/ds18x20.proto
+++ b/proto/wippersnapper/ds18x20.proto
@@ -31,10 +31,10 @@ message D2B {
 * NOTE: This API currently only supports ONE device per OneWire bus.
 */
 message Add {
-  string onewire_pin                   = 1; /** The desired pin to use as a OneWire bus. */
-  int32 sensor_resolution              = 2; /** The desired sensor resolution (9, 10, 11, or 12 bits). */
-  float period                         = 3; /** The desired period to read the sensor, in seconds. */
-  repeated ws.sensor.Type sensor_types = 4; /** SI types used by the DS18x20 sensor. */
+  string onewire_pin              = 1; /** The desired pin to use as a OneWire bus. */
+  int32 sensor_resolution         = 2; /** The desired sensor resolution (9, 10, 11, or 12 bits). */
+  float period                    = 3; /** The desired period to read the sensor, in seconds. */
+  repeated ws.sensor.Type sensors = 4; /** SI types used by the DS18x20 sensor. */
 }
 
 /**
@@ -58,6 +58,6 @@ message Remove {
 * Event event represents data from **one** DS18X20 sensor.
 */
 message Event {
-  string onewire_pin                     = 1; /** The desired pin to use as a OneWire bus. */
-  repeated ws.sensor.Event sensor_events = 2; /** The DS18X20's SensorEvent. */
+  string onewire_pin              = 1; /** The desired pin to use as a OneWire bus. */
+  repeated ws.sensor.Event events = 2; /** The DS18X20's SensorEvent. */
 }

--- a/proto/wippersnapper/error.proto
+++ b/proto/wippersnapper/error.proto
@@ -64,7 +64,7 @@ message ErrorD2B {
   ComponentType type = 1;
   oneof component_id {
     string pin = 2;
-    ws.i2c.DeviceDescriptor i2c = 3;
+    ws.i2c.Descriptor i2c = 3;
     ws.uart.Descriptor uart = 4;
   }
   string error = 5;

--- a/proto/wippersnapper/expander.proto
+++ b/proto/wippersnapper/expander.proto
@@ -28,26 +28,26 @@ message D2B {
 * Add adds an expander to the hardware.
 */
 message Add {
-  i2c.DeviceAddOrReplace cfg_i2c = 1; /** I2C configuration for the expander. */
+  i2c.Add cfg_i2c = 1; /** I2C configuration for the expander. */
 }
 
 /**
 * Added represents a message from the hardware indicating an expander was added.
 */
 message Added {
-  i2c.DeviceAddedOrReplaced response_i2c = 1; /** I2C configuration response. */
+  i2c.Added response_i2c = 1; /** I2C configuration response. */
 }
 
 /**
 * Remove removes an analog pin from the hardware.
 */
 message Remove {
-  i2c.DeviceRemove cfg_i2c = 1; /** I2C configuration for the expander to remove. */
+  i2c.Remove cfg_i2c = 1; /** I2C configuration for the expander to remove. */
 }
 
 /**
 * Removed represents a message from the device indicating an expander was removed.
 */
 message Removed {
-  i2c.DeviceRemoved response_i2c = 1; /** I2C configuration response. */
+  i2c.Removed response_i2c = 1; /** I2C configuration response. */
 }

--- a/proto/wippersnapper/gps.proto
+++ b/proto/wippersnapper/gps.proto
@@ -10,8 +10,8 @@ import "uart.proto";
  */
 message B2D {
   oneof payload {
-    DeviceAddOrReplace device_add_replace = 1;
-    DeviceRemove device_remove            = 2;
+    Add add       = 1;
+    Remove remove = 2;
   }
 }
 
@@ -20,45 +20,45 @@ message B2D {
  */
 message D2B {
   oneof payload {
-    DeviceAddedOrReplaced device_added_replaced = 1;
-    DeviceRemoved device_removed                = 2;
-    Event event = 3;
+    Added added     = 1;
+    Removed removed = 2;
+    Event event     = 3;
   }
 }
 
 /**
- * DeviceAddOrReplace represents a message to add or replace a GPS device,
+ * Add represents a message to add or replace a GPS device,
  * including the transport and GPS-specific configuration options.
  */
-message DeviceAddOrReplace {
-  i2c.DeviceAddOrReplace add_i2c  = 1;
-  uart.Add               add_uart = 2;
-  Config                 config   = 3;
+message Add {
+  i2c.Add add_i2c   = 1;
+  uart.Add add_uart = 2;
+  Config config     = 3;
 }
 
 /**
- * DeviceAddedOrReplaced represents a message indicating a GPS device was added or replaced.
+ * Added represents a message indicating a GPS device was added or replaced.
  */
-message DeviceAddedOrReplaced {
-  i2c.DeviceAddedOrReplaced added_i2c  = 1;
-  uart.Added                added_uart = 2;
+message Added {
+  i2c.Added added_i2c   = 1;
+  uart.Added added_uart = 2;
 }
 
 /**
- * DeviceRemove represents a message to remove a GPS device,
+ * Remove represents a message to remove a GPS device,
  * including the transport-specific options.
  */
-message DeviceRemove {
-  i2c.DeviceRemove remove_i2c  = 1;
-  uart.Remove      remove_uart = 2;
+message Remove {
+  i2c.Remove remove_i2c   = 1;
+  uart.Remove remove_uart = 2;
 }
 
 /**
- * DeviceRemoved represents a message indicating a GPS device was removed.
+ * Removed represents a message indicating a GPS device was removed.
  */
-message DeviceRemoved {
-  i2c.DeviceRemoved removed_i2c  = 1;
-  uart.Removed      removed_uart = 2;
+message Removed {
+  i2c.Removed removed_i2c   = 1;
+  uart.Removed removed_uart = 2;
 }
 
 /**

--- a/proto/wippersnapper/i2c.options
+++ b/proto/wippersnapper/i2c.options
@@ -1,5 +1,5 @@
 # i2c.options
 ws.i2c.Probed.results                         max_count:16
-ws.i2c.DeviceAddOrReplace.device_name         max_size:16
-ws.i2c.DeviceAddOrReplace.device_sensor_types max_count:16
-ws.i2c.DeviceEvent.device_events              max_count:16
+ws.i2c.Add.name         max_size:16
+ws.i2c.Add.sensors max_count:16
+ws.i2c.Event.events              max_count:16

--- a/proto/wippersnapper/i2c.options
+++ b/proto/wippersnapper/i2c.options
@@ -1,5 +1,5 @@
 # i2c.options
-ws.i2c.Probed.results                         max_count:16
-ws.i2c.Add.name         max_size:16
-ws.i2c.Add.sensors max_count:16
-ws.i2c.Event.events              max_count:16
+ws.i2c.Probed.results max_count:16
+ws.i2c.Add.name       max_size:16
+ws.i2c.Add.sensors    max_count:16
+ws.i2c.Event.events   max_count:16

--- a/proto/wippersnapper/i2c.options
+++ b/proto/wippersnapper/i2c.options
@@ -1,5 +1,5 @@
 # i2c.options
 ws.i2c.Probed.results max_count:16
 ws.i2c.Add.name       max_size:16
-ws.i2c.Add.sensors    max_count:16
+ws.i2c.Add.types      max_count:16
 ws.i2c.Event.events   max_count:16

--- a/proto/wippersnapper/i2c.proto
+++ b/proto/wippersnapper/i2c.proto
@@ -107,12 +107,12 @@ message Descriptor {
 * Add is a message for initializing (or replacing/updating) an i2c device.
 */
 message Add {
-  Descriptor descriptor               = 1; /** The I2c device's address and metadata. */
+  Descriptor descriptor             = 1; /** The I2c device's address and metadata. */
   /** The I2c device's name, MUST MATCH the name on the JSON
    *  definition file on the Wippersnapper_Components repo. */
-  string name                         = 2;
-  float period                        = 3; /** The desired period to update the I2c device's sensor(s), in seconds. */
-  map<uint32, ws.sensor.Type> sensors = 4; /** SI Types for each sensor on the I2c device. */
+  string name                       = 2;
+  float period                      = 3; /** The desired period to update the I2c device's sensor(s), in seconds. */
+  map<uint32, ws.sensor.Type> types = 4; /** SI Types for each sensor on the I2c device. */
 }
 
 /**

--- a/proto/wippersnapper/i2c.proto
+++ b/proto/wippersnapper/i2c.proto
@@ -9,9 +9,9 @@ import "sensor.proto";
  */
 message B2D {
   oneof payload {
-    Probe probe                           = 1;
-    DeviceAddOrReplace device_add_replace = 2;
-    DeviceRemove device_remove            = 3;
+    Probe probe   = 1;
+    Add add       = 2;
+    Remove remove = 3;
   }
 }
 
@@ -20,10 +20,10 @@ message B2D {
  */
 message D2B {
   oneof payload {
-    Probed probed                               = 1;
-    DeviceAddedOrReplaced device_added_replaced = 2;
-    DeviceRemoved device_removed                = 3;
-    DeviceEvent device_event                    = 4;
+    Probed probed   = 1;
+    Added added     = 2;
+    Removed removed = 3;
+    Event event     = 4;
   }
 }
 
@@ -40,15 +40,15 @@ enum BusStatus {
 }
 
 /**
-* DeviceStatus represents the state of an I2C device/peripheral
+* Status represents the state of an I2C device/peripheral
 */
-enum DeviceStatus {
-  DS_UNSPECIFIED             = 0; /** Unspecified error occurred. **/
-  DS_SUCCESS                 = 1; /** I2C device successfully initialized. **/
-  DS_FAIL_INIT               = 2; /** I2C device failed to initialize. **/
-  DS_FAIL_DEINIT             = 3; /** I2C device failed to deinitialize. **/
-  DS_FAIL_UNSUPPORTED_SENSOR = 4; /** WipperSnapper version is outdated and does not include this device. **/
-  DS_NOT_FOUND               = 5; /** I2C device not found on the bus. **/
+enum Status {
+  S_UNSPECIFIED             = 0; /** Unspecified error occurred. **/
+  S_SUCCESS                 = 1; /** I2C device successfully initialized. **/
+  S_FAIL_INIT               = 2; /** I2C device failed to initialize. **/
+  S_FAIL_DEINIT             = 3; /** I2C device failed to deinitialize. **/
+  S_FAIL_UNSUPPORTED_SENSOR = 4; /** WipperSnapper version is outdated and does not include this device. **/
+  S_NOT_FOUND               = 5; /** I2C device not found on the bus. **/
 }
 /**
  * Represents a separate I2C address space, either a Bus or a Mux.
@@ -96,54 +96,54 @@ message Probed {
 }
 
 /**
-* DeviceDescriptor represents a specific device's I2C address within an address space.
+* Descriptor represents a specific device's I2C address within an address space.
 */
-message DeviceDescriptor {
+message Descriptor {
   AddressSpace address_space = 1; /** Which address space this device lives in, with mux_channel required. **/
   uint32 address             = 2; /** Device's i2c address, either on the bus or the mux **/
 }
 
 /**
-* DeviceAddOrReplace is a message for initializing (or replacing/updating) an i2c device.
+* Add is a message for initializing (or replacing/updating) an i2c device.
 */
-message DeviceAddOrReplace {
-  DeviceDescriptor device_description             = 1; /** The I2c device's address and metadata. */
+message Add {
+  Descriptor descriptor               = 1; /** The I2c device's address and metadata. */
   /** The I2c device's name, MUST MATCH the name on the JSON
    *  definition file on the Wippersnapper_Components repo. */
-  string device_name                              = 2;
-  float device_period                             = 3; /** The desired period to update the I2c device's sensor(s), in seconds. */
-  map<uint32, ws.sensor.Type> device_sensor_types = 4; /** SI Types for each sensor on the I2c device. */
+  string name                         = 2;
+  float period                        = 3; /** The desired period to update the I2c device's sensor(s), in seconds. */
+  map<uint32, ws.sensor.Type> sensors = 4; /** SI Types for each sensor on the I2c device. */
 }
 
 /**
-* DeviceAddedOrReplaced contains the response from a device after processing a DeviceAddOrReplace message.
+* Added contains the response from a device after processing a Add message.
 */
-message DeviceAddedOrReplaced {
-  DeviceDescriptor device_description = 1; /** The I2c device's address and metadata, unless there was an error. **/
-  BusStatus bus_status                = 2; /** The I2c bus' status, in case of bus error. **/
-  DeviceStatus device_status          = 3; /** The I2c device's status, in case of device error. **/
+message Added {
+  Descriptor descriptor = 1; /** The I2c device's address and metadata, unless there was an error. **/
+  BusStatus bus_status  = 2; /** The I2c bus' status, in case of bus error. **/
+  Status status         = 3; /** The I2c device's status, in case of device error. **/
 }
 
 /**
-* DeviceRemove represents a request to de-init an i2c device.
+* Remove represents a request to de-init an i2c device.
 */
-message DeviceRemove {
-  DeviceDescriptor device_description = 1; /** The I2c device's address and metadata. */
+message Remove {
+  Descriptor descriptor = 1; /** The I2c device's address and metadata. */
 }
 
 /**
-* DeviceRemoved represents a response to a I2cDeviceRemove message.
+* Removed represents a response to a I2cRemove message.
 */
-message DeviceRemoved {
-  DeviceDescriptor device_description = 1; /** The I2c device's address and metadata. */
-  bool did_remove                     = 2; /** True if the I2C device was successfully removed from the controller, False otherwise. **/
+message Removed {
+  Descriptor descriptor = 1; /** The I2c device's address and metadata. */
+  bool did_remove       = 2; /** True if the I2C device was successfully removed from the controller, False otherwise. **/
 }
 
 /**
-* Each DeviceEvent represents data from **one** I2C device, containing one or more sensors.
+* Each Event represents data from **one** I2C device, containing one or more sensors.
 */
-message DeviceEvent {
-  DeviceDescriptor device_description        = 1; /** The I2c device's address and metadata. */
-  map<uint32, ws.sensor.Event> device_events = 2; /** An event from each of the device's configured sensors. */
+message Event {
+  Descriptor descriptor               = 1; /** The I2c device's address and metadata. */
+  map<uint32, ws.sensor.Event> events = 2; /** An event from each of the device's configured sensors. */
 }
 

--- a/proto/wippersnapper/i2c.proto
+++ b/proto/wippersnapper/i2c.proto
@@ -107,12 +107,12 @@ message DeviceDescriptor {
 * DeviceAddOrReplace is a message for initializing (or replacing/updating) an i2c device.
 */
 message DeviceAddOrReplace {
-  DeviceDescriptor device_description         = 1; /** The I2c device's address and metadata. */
+  DeviceDescriptor device_description             = 1; /** The I2c device's address and metadata. */
   /** The I2c device's name, MUST MATCH the name on the JSON
    *  definition file on the Wippersnapper_Components repo. */
-  string device_name                          = 2;
-  float device_period                         = 3; /** The desired period to update the I2c device's sensor(s), in seconds. */
-  repeated ws.sensor.Type device_sensor_types = 4; /** SI Types for each sensor on the I2c device. */
+  string device_name                              = 2;
+  float device_period                             = 3; /** The desired period to update the I2c device's sensor(s), in seconds. */
+  map<uint32, ws.sensor.Type> device_sensor_types = 4; /** SI Types for each sensor on the I2c device. */
 }
 
 /**
@@ -143,7 +143,7 @@ message DeviceRemoved {
 * Each DeviceEvent represents data from **one** I2C device, containing one or more sensors.
 */
 message DeviceEvent {
-  DeviceDescriptor device_description    = 1; /** The I2c device's address and metadata. */
-  repeated ws.sensor.Event device_events = 2; /** An event from each of the device's configured sensors. */
+  DeviceDescriptor device_description        = 1; /** The I2c device's address and metadata. */
+  map<uint32, ws.sensor.Event> device_events = 2; /** An event from each of the device's configured sensors. */
 }
 

--- a/proto/wippersnapper/uart.options
+++ b/proto/wippersnapper/uart.options
@@ -1,7 +1,7 @@
 # uart.options
-ws.uart.DeviceConfig.id            max_size: 32
-ws.uart.SerialConfig.pin_rx        max_size: 16
-ws.uart.SerialConfig.pin_tx        max_size: 16
-ws.uart.GenericInputConfig.sensors max_count:15
-ws.uart.PM25AQIConfig.sensors      max_count:15
-ws.uart.InputEvent.events          max_count:15
+ws.uart.DeviceConfig.id          max_size: 32
+ws.uart.SerialConfig.pin_rx      max_size: 16
+ws.uart.SerialConfig.pin_tx      max_size: 16
+ws.uart.GenericInputConfig.types max_count:15
+ws.uart.PM25AQIConfig.types      max_count:15
+ws.uart.InputEvent.events        max_count:15

--- a/proto/wippersnapper/uart.options
+++ b/proto/wippersnapper/uart.options
@@ -1,7 +1,7 @@
 # uart.options
-ws.uart.DeviceConfig.device_id          max_size: 32
-ws.uart.SerialConfig.pin_rx             max_size: 16
-ws.uart.SerialConfig.pin_tx             max_size: 16
-ws.uart.GenericInputConfig.sensor_types max_count:15
-ws.uart.PM25AQIConfig.sensor_types      max_count:15
-ws.uart.InputEvent.events               max_count:15
+ws.uart.DeviceConfig.id            max_size: 32
+ws.uart.SerialConfig.pin_rx        max_size: 16
+ws.uart.SerialConfig.pin_tx        max_size: 16
+ws.uart.GenericInputConfig.sensors max_count:15
+ws.uart.PM25AQIConfig.sensors      max_count:15
+ws.uart.InputEvent.events          max_count:15

--- a/proto/wippersnapper/uart.proto
+++ b/proto/wippersnapper/uart.proto
@@ -107,7 +107,7 @@ message GenericInputConfig {
   string name                         = 1; /** The name used to identify the device. */
   GenericDeviceLineEnding line_ending = 2; /** The line ending used by the device. */
   int32 period                        = 3; /** The period to poll the device, in milliseconds */
-  repeated ws.sensor.Type sensors     = 4; /** SI Types for each sensor on the UART device. */
+  repeated ws.sensor.Type types       = 4; /** SI Types for each sensor on the UART device. */
 }
 
 /**
@@ -125,7 +125,7 @@ message TrinamicDynamixelConfig {
 message PM25AQIConfig {
   bool is_pm1006                  = 1; /** True if the device is a PM1006 AQ sensor, Defaults to False. */
   int32 period                    = 2; /** The period to poll the device, in milliseconds */
-  repeated ws.sensor.Type sensors = 3; /** SI Types for each sensor on the I2c device. */
+  repeated ws.sensor.Type types   = 3; /** SI Types for each sensor on the I2c device. */
 }
 
 /**

--- a/proto/wippersnapper/uart.proto
+++ b/proto/wippersnapper/uart.proto
@@ -90,7 +90,7 @@ enum GenericDeviceLineEnding {
 message SerialConfig {
   string pin_rx           = 1; /** The pin on which to receive on. */
   string pin_tx           = 2; /** The pin on which to transmit with. */
-  string device_name      = 3; /** (For CPython ONLY) The device name, i.e: /dev/ttyUSB0. */
+  string name             = 3; /** (For CPython ONLY) The device name, i.e: /dev/ttyUSB0. */
   uint32 uart_nbr         = 4; /** The UART port number to use, eg: 0, 1, 2, etc. */
   uint32 baud_rate        = 5; /** The desired baudrate, in bits per second. */
   PacketFormat format     = 6; /** The data, parity, and stop bits. */
@@ -104,10 +104,10 @@ message SerialConfig {
 * containing device-specific configuration info for generic UART input devices.
 */
 message GenericInputConfig {
-  string name                          = 1; /** The name used to identify the device. */
-  GenericDeviceLineEnding line_ending  = 2; /** The line ending used by the device. */
-  int32 period                         = 3; /** The period to poll the device, in milliseconds */
-  repeated ws.sensor.Type sensor_types = 4; /** SI Types for each sensor on the UART device. */
+  string name                         = 1; /** The name used to identify the device. */
+  GenericDeviceLineEnding line_ending = 2; /** The line ending used by the device. */
+  int32 period                        = 3; /** The period to poll the device, in milliseconds */
+  repeated ws.sensor.Type sensors     = 4; /** SI Types for each sensor on the UART device. */
 }
 
 /**
@@ -115,7 +115,7 @@ message GenericInputConfig {
 * containing device-specific configuration info for Trinamic stepper or DYNAMIXEL servos.
 */
 message TrinamicDynamixelConfig {
-  uint32 device_id = 1; /** The device identifier, used for sub-addressing (multiple servos on one UART). */
+  uint32 id = 1; /** The device identifier, used for sub-addressing (multiple servos on one UART). */
 }
 
 /**
@@ -123,9 +123,9 @@ message TrinamicDynamixelConfig {
 * containing device-specific configuration info for PM2.5 AQI sensors.
 */
 message PM25AQIConfig {
-  bool is_pm1006                       = 1; /** True if the device is a PM1006 AQ sensor, Defaults to False. */
-  int32 period                         = 2; /** The period to poll the device, in milliseconds */
-  repeated ws.sensor.Type sensor_types = 3; /** SI Types for each sensor on the I2c device. */
+  bool is_pm1006                  = 1; /** True if the device is a PM1006 AQ sensor, Defaults to False. */
+  int32 period                    = 2; /** The period to poll the device, in milliseconds */
+  repeated ws.sensor.Type sensors = 3; /** SI Types for each sensor on the I2c device. */
 }
 
 /**
@@ -134,8 +134,8 @@ message PM25AQIConfig {
 * This message is never sent directly, it is packed inside Add.
 */
 message DeviceConfig {
-  DeviceType device_type                       = 1; /** The type of device connected to the UART port. */
-  string device_id                             = 2; /** The unique identifier string for the UART device. */
+  DeviceType type                              = 1; /** The type of device connected to the UART port. */
+  string id                                    = 2; /** The unique identifier string for the UART device. */
   oneof config {
     GenericInputConfig generic_input           = 3; /** OPTIONAL configuration for a generic UART input device. */
     TrinamicDynamixelConfig trinamic_dynamixel = 4; /** OPTIONAL configuration for a Trinamic stepper or DYNAMIXEL servo. */
@@ -149,7 +149,7 @@ message DeviceConfig {
 message Descriptor {
   uint32 uart_nbr     = 1; /** The UART port number (eg: 0, 1, 2, etc.) that the device is attached to. */
   DeviceType type     = 2; /** The category of device attached to the UART port, corresponds to its driver type. */
-  string device_id    = 3; /** The unique identifier string for the UART device. */
+  string id           = 3; /** The unique identifier string for the UART device. */
 }
 
 /**
@@ -168,7 +168,7 @@ message Add {
 */
 message Added {
   Descriptor descriptor = 1; /** The descriptor of the device that was added. */
-  bool success     = 2; /** True if the device on the UART port was successfully initialized, False otherwise. */
+  bool success          = 2; /** True if the device on the UART port was successfully initialized, False otherwise. */
 }
 
 /*
@@ -196,8 +196,8 @@ message Write {
   Descriptor descriptor = 1; /** The descriptor of the device to write to. */
   // Payload
   oneof payload {
-    bytes bytes_data = 2; /** Raw data to send to the device, corresponds to the Wiring API Serial.write(). */
-    string text_data = 3; /** String to send to the device, corresponds to the Wiring API Serial.print(). */
+    bytes bytes_data    = 2; /** Raw data to send to the device, corresponds to the Wiring API Serial.write(). */
+    string text_data    = 3; /** String to send to the device, corresponds to the Wiring API Serial.print(). */
   }
 }
 
@@ -207,7 +207,7 @@ message Write {
 */
 message Written {
   Descriptor descriptor = 1; /** The descriptor of the device that was written to. */
-  uint32 bytes_written = 2; /** The number of bytes written to the device. */
+  uint32 bytes_written  = 2; /** The number of bytes written to the device. */
 }
 
 /**
@@ -217,6 +217,6 @@ message Written {
 * It can contain multiple SensorEvents if the device has multiple sensors.
 */
 message InputEvent {
-  Descriptor descriptor = 1; /** The descriptor of the device that generated the input event. */
+  Descriptor descriptor           = 1; /** The descriptor of the device that generated the input event. */
   repeated ws.sensor.Event events = 2; /** Required, but optionally repeated, SensorEvent from a sensor. */
 }


### PR DESCRIPTION
replaces `repeated TYPE ...` with `map<uint32, TYPE> ...` for I2C Add/Replace component types and DeviceEvent sensor events.

This allows multiple sensors of the same type to be defined in the component JSON without ambiguity by using ids in the JSON that map to the `uint32` map keys in the protobufs.