### PR TITLE
Add - Settings

### DIFF
--- a/proto/wippersnapper/analogin.proto
+++ b/proto/wippersnapper/analogin.proto
@@ -33,31 +33,15 @@ enum SampleMode {
 }
 
 /**
-* Gain specifies the pin's ADC gain setting.
-*/
-enum Gain {
-  G_UNSPECIFIED = 0; /** Use platform default gain. */
-  G_1X          = 1; /** No gain, or unity gain. */
-  G_2X          = 2; /** Gain of 2x */
-  G_4X          = 3; /** Gain of 4x */
-  G_8X          = 4; /** Gain of 8x */
-  G_16X         = 5; /** Gain of 16x */
-  G_32X         = 6; /** Gain of 32x */
-  G_64X         = 7; /** Gain of 64x */
-  G_128X        = 8; /** Gain of 128x */
-  G_2_3X        = 9; /** Gain of 2/3x (Utilized by ADS1x15) */
-}
-
-/**
 * Add adds an analog input pin to the device.
 */
 message Add {
-  string pin_name          = 1; /** Name of the pin. */
-  float period             = 2; /** Time between reads, in seconds. */
-  ws.sensor.Type read_mode = 3; /** Desired read mode for the pin. */
-  SampleMode sample_mode   = 4; /** Desired sample mode for the pin. */
-  float ref_voltage        = 5; /** Reference voltage for the pin, in volts. */
-  Gain gain                = 6; /** Optional ADC gain setting. */
+  string pin_name              = 1; /** Name of the pin. */
+  float period                 = 2; /** Time between reads, in seconds. */
+  ws.sensor.Type read_mode     = 3; /** Desired read mode for the pin. */
+  SampleMode sample_mode       = 4; /** Desired sample mode for the pin. */
+  float ref_voltage            = 5; /** Reference voltage for the pin, in volts. */
+  map<string, uint32> settings = 6; /** Additional configuration options for the pin. **/
 }
 
 /**

--- a/proto/wippersnapper/analogin.proto
+++ b/proto/wippersnapper/analogin.proto
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 syntax = "proto3";
 package ws.analogin;
+import "config.proto";
 import "sensor.proto";
 
 /**
@@ -41,7 +42,7 @@ message Add {
   ws.sensor.Type read_mode     = 3; /** Desired read mode for the pin. */
   SampleMode sample_mode       = 4; /** Desired sample mode for the pin. */
   float ref_voltage            = 5; /** Reference voltage for the pin, in volts. */
-  map<string, uint32> settings = 6; /** Additional configuration options for the pin. **/
+  ws.config.Settings settings  = 6; /** Additional configuration options for the pin. **/
 }
 
 /**

--- a/proto/wippersnapper/analogin.proto
+++ b/proto/wippersnapper/analogin.proto
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: MIT
 syntax = "proto3";
 package ws.analogin;
-import "config.proto";
 import "sensor.proto";
 
 /**
@@ -42,7 +41,6 @@ message Add {
   ws.sensor.Type read_mode     = 3; /** Desired read mode for the pin. */
   SampleMode sample_mode       = 4; /** Desired sample mode for the pin. */
   float ref_voltage            = 5; /** Reference voltage for the pin, in volts. */
-  ws.config.Settings settings  = 6; /** Additional configuration options for the pin. **/
 }
 
 /**

--- a/proto/wippersnapper/config.proto
+++ b/proto/wippersnapper/config.proto
@@ -1,0 +1,23 @@
+// SPDX-FileCopyrightText: 2026 Brent Rubell and Loren Norman for Adafruit Industries
+// SPDX-License-Identifier: MIT
+syntax = "proto3";
+package ws.config;
+
+/**
+ * Value represents a configuration value that, may be one of several types.
+ */
+message Value {
+  oneof value {
+    string str_value = 1;
+    int32 int_value = 2;
+    float float_value = 3;
+    bool bool_value = 4;
+  }
+}
+
+/**
+ * Settings represents a collection of configuration settings, where each setting is a key-value pair.
+ */
+message Settings {
+  map<string, Value> settings = 1;
+}

--- a/proto/wippersnapper/expander.proto
+++ b/proto/wippersnapper/expander.proto
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 syntax = "proto3";
 package ws.expander;
+import "config.proto";
 import "i2c.proto";
 
 /**
@@ -25,28 +26,29 @@ message D2B {
 }
 
 /**
-* Add adds an expander to the hardware.
+* Add adds an expander component to the hardware.
 */
 message Add {
-  i2c.Add cfg_i2c = 1; /** I2C configuration for the expander. */
+  i2c.Add cfg_i2c             = 1; /** I2C configuration for the expander. */
+  ws.config.Settings settings = 2; /** Additional configuration options for the expander. **/
 }
 
 /**
-* Added represents a message from the hardware indicating an expander was added.
+* Added represents a message from the hardware indicating an expander component was added.
 */
 message Added {
   i2c.Added response_i2c = 1; /** I2C configuration response. */
 }
 
 /**
-* Remove removes an analog pin from the hardware.
+* Remove removes an expander component from the hardware.
 */
 message Remove {
   i2c.Remove cfg_i2c = 1; /** I2C configuration for the expander to remove. */
 }
 
 /**
-* Removed represents a message from the device indicating an expander was removed.
+* Removed represents a message from the device indicating an expander component was removed.
 */
 message Removed {
   i2c.Removed response_i2c = 1; /** I2C configuration response. */

--- a/proto/wippersnapper/expander.proto
+++ b/proto/wippersnapper/expander.proto
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: MIT
 syntax = "proto3";
 package ws.expander;
-import "config.proto";
 import "i2c.proto";
 
 /**
@@ -30,7 +29,6 @@ message D2B {
 */
 message Add {
   i2c.Add cfg_i2c             = 1; /** I2C configuration for the expander. */
-  ws.config.Settings settings = 2; /** Additional configuration options for the expander. **/
 }
 
 /**

--- a/proto/wippersnapper/i2c.proto
+++ b/proto/wippersnapper/i2c.proto
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 syntax = "proto3";
 package ws.i2c;
+import "config.proto";
 import "sensor.proto";
 
 /**
@@ -108,12 +109,10 @@ message Descriptor {
 */
 message Add {
   Descriptor descriptor             = 1; /** The I2c device's address and metadata. */
-  /** The I2c device's name, MUST MATCH the name on the JSON
-   *  definition file on the Wippersnapper_Components repo. */
-  string name                       = 2;
+  string name                       = 2; /** The I2c device's name. **/
   float period                      = 3; /** The desired period to update the I2c device's sensor(s), in seconds. */
   map<uint32, ws.sensor.Type> types = 4; /** SI Types for each sensor on the I2c device. */
-  map<string, uint32> settings      = 6; /** Additional device configuration options. **/
+  ws.config.Settings settings       = 5; /** Additional device configuration options. **/
 }
 
 /**

--- a/proto/wippersnapper/i2c.proto
+++ b/proto/wippersnapper/i2c.proto
@@ -113,6 +113,7 @@ message Add {
   string name                       = 2;
   float period                      = 3; /** The desired period to update the I2c device's sensor(s), in seconds. */
   map<uint32, ws.sensor.Type> types = 4; /** SI Types for each sensor on the I2c device. */
+  map<string, uint32> settings      = 6; /** Additional device configuration options. **/
 }
 
 /**


### PR DESCRIPTION
This pull request allows users to select options such as gain, oversampling, measurement rate, power mode, etc.  It replaces the fixed enum for AnalogIn `Gain` with the generic settings map, and uses the same settings map for I2C device configuration.

**Specification**
Design overview:
1) The definition is the source of truth for what settings are exposed for the pin/component
2) The sensor driver is only place where the index 2 of gain maps. 
3) Protobuf never changes when a component is added, or when a new setting is added to an existing component. 

Expected Operation:
1) Let's assume a user is in the New Component flow in IO.Adafruit.com
2) User selects BME280
3) User clicks "Advanced Options" and fills: Temperature Oversampling = 4x, PRessure Oversampling = 8x, Humidity oversampling = 2x.

Protobuf msg is filled using a `settings` field, which holds _all_ of the device's setting configurations.
```
map<string, uint32> settings = 3;  
```
where:
```
    settings: {
      "temp_oversampling": 3,      // "4x"
      "pressure_oversampling": 4,  // "8x"
      "humidity_oversampling": 2   // "2x"
    }
```

4) Message is sent to the device 
5) Firmware passes the map to the driver
6) Driver stores the raw index map 
7) Driver interprets the raw index map during its `begin()` call

--- 

Related: https://github.com/adafruit/Wippersnapper_Components/pull/327
Resolves #126 
