### PR TITLE
Align Uart

### DIFF
--- a/proto/wippersnapper/uart.options
+++ b/proto/wippersnapper/uart.options
@@ -1,7 +1,5 @@
 # uart.options
 ws.uart.Add.name                 max_size: 32
-ws.uart.SerialConfig.pin_rx      max_size: 16
-ws.uart.SerialConfig.pin_tx      max_size: 16
 ws.uart.GenericInputConfig.types max_count:15
 ws.uart.PM25AQIConfig.types      max_count:15
 ws.uart.Event.events             max_count:15

--- a/proto/wippersnapper/uart.options
+++ b/proto/wippersnapper/uart.options
@@ -1,5 +1,5 @@
 # uart.options
-ws.uart.DeviceConfig.id          max_size: 32
+ws.uart.Descriptor.id          max_size: 32
 ws.uart.SerialConfig.pin_rx      max_size: 16
 ws.uart.SerialConfig.pin_tx      max_size: 16
 ws.uart.GenericInputConfig.types max_count:15

--- a/proto/wippersnapper/uart.options
+++ b/proto/wippersnapper/uart.options
@@ -1,5 +1,5 @@
 # uart.options
-ws.uart.Descriptor.id          max_size: 32
+ws.uart.Add.name                 max_size: 32
 ws.uart.SerialConfig.pin_rx      max_size: 16
 ws.uart.SerialConfig.pin_tx      max_size: 16
 ws.uart.GenericInputConfig.types max_count:15

--- a/proto/wippersnapper/uart.proto
+++ b/proto/wippersnapper/uart.proto
@@ -72,14 +72,12 @@ enum GenericDeviceLineEnding {
 * This message is never sent directly, it is packed inside Add.
 */
 message SerialConfig {
-  string pin_rx           = 1; /** The pin on which to receive on. */
-  string pin_tx           = 2; /** The pin on which to transmit with. */
-  string name             = 3; /** (For CPython ONLY) The device name, i.e: /dev/ttyUSB0. */
-  uint32 baud_rate        = 4; /** The desired baudrate, in bits per second. */
-  PacketFormat format     = 5; /** The data, parity, and stop bits. */
-  float timeout           = 6; /** Maximum milliseconds to wait for serial data. Defaults to 1000 ms. */
-  bool use_sw_serial      = 7; /** Use software serial instead of hardware serial. Defaults to False. */
-  bool sw_serial_invert   = 8; /** Optional: Inverts the UART signal on RX and TX pins. Defaults to False. */
+  string name             = 1; /** (For CPython ONLY) The device name, i.e: /dev/ttyUSB0. */
+  uint32 baud_rate        = 2; /** The desired baudrate, in bits per second. */
+  PacketFormat format     = 3; /** The data, parity, and stop bits. */
+  float timeout           = 4; /** Maximum milliseconds to wait for serial data. Defaults to 1000 ms. */
+  bool use_sw_serial      = 5; /** Use software serial instead of hardware serial. Defaults to False. */
+  bool sw_serial_invert   = 6; /** Optional: Inverts the UART signal on RX and TX pins. Defaults to False. */
 }
 
 /**
@@ -128,8 +126,8 @@ message DeviceConfig {
 * Descriptor represents a message that uniquely identifies a UART device.
 */
 message Descriptor {
-  uint32 pin_scl = 1; /** The pin on which to receive on. */
-  uint32 pin_sda = 2; /** The pin on which to transmit with. */
+  uint32 pin_rx = 1; /** The pin on which to receive on. */
+  uint32 pin_tx = 2; /** The pin on which to transmit with. */
 }
 
 /**

--- a/proto/wippersnapper/uart.proto
+++ b/proto/wippersnapper/uart.proto
@@ -88,12 +88,11 @@ message SerialConfig {
   string pin_rx           = 1; /** The pin on which to receive on. */
   string pin_tx           = 2; /** The pin on which to transmit with. */
   string name             = 3; /** (For CPython ONLY) The device name, i.e: /dev/ttyUSB0. */
-  uint32 uart_nbr         = 4; /** The UART port number to use, eg: 0, 1, 2, etc. */
-  uint32 baud_rate        = 5; /** The desired baudrate, in bits per second. */
-  PacketFormat format     = 6; /** The data, parity, and stop bits. */
-  float timeout           = 7; /** Maximum milliseconds to wait for serial data. Defaults to 1000 ms. */
-  bool use_sw_serial      = 8; /** Use software serial instead of hardware serial. Defaults to False. */
-  bool sw_serial_invert   = 9; /** Optional: Inverts the UART signal on RX and TX pins. Defaults to False. */
+  uint32 baud_rate        = 4; /** The desired baudrate, in bits per second. */
+  PacketFormat format     = 5; /** The data, parity, and stop bits. */
+  float timeout           = 6; /** Maximum milliseconds to wait for serial data. Defaults to 1000 ms. */
+  bool use_sw_serial      = 7; /** Use software serial instead of hardware serial. Defaults to False. */
+  bool sw_serial_invert   = 8; /** Optional: Inverts the UART signal on RX and TX pins. Defaults to False. */
 }
 
 /**
@@ -131,12 +130,10 @@ message PM25AQIConfig {
 * This message is never sent directly, it is packed inside Add.
 */
 message DeviceConfig {
-  DeviceType type                              = 1; /** The type of device connected to the UART port. */
-  string id                                    = 2; /** The unique identifier string for the UART device. */
   oneof config {
-    GenericInputConfig generic_input           = 3; /** OPTIONAL configuration for a generic UART input device. */
-    TrinamicDynamixelConfig trinamic_dynamixel = 4; /** OPTIONAL configuration for a Trinamic stepper or DYNAMIXEL servo. */
-    PM25AQIConfig pm25aqi                      = 5; /** OPTIONAL configuration for a PM2.5 AQI sensor. */
+    GenericInputConfig generic_input           = 1; /** OPTIONAL configuration for a generic UART input device. */
+    TrinamicDynamixelConfig trinamic_dynamixel = 2; /** OPTIONAL configuration for a Trinamic stepper or DYNAMIXEL servo. */
+    PM25AQIConfig pm25aqi                      = 3; /** OPTIONAL configuration for a PM2.5 AQI sensor. */
   }
 }
 
@@ -154,9 +151,10 @@ message Descriptor {
 * to configure a device on a UART port for communication.
 */
 message Add {
-  SerialConfig cfg_serial = 1; /** The Serial configuration. */
-  DeviceConfig cfg_device = 2; /** The device-specific configuration. */
-  Write write             = 3; /** Optional initial write for a UART device, used during check-in. */
+  Descriptor   descriptor = 1; /** The descriptor of the device to add. */
+  SerialConfig cfg_serial = 2; /** The Serial configuration. */
+  DeviceConfig cfg_device = 3; /** The device-specific configuration. */
+  Write write             = 4; /** Optional initial write for a UART device, used during check-in. */
 }
 
 /*

--- a/proto/wippersnapper/uart.proto
+++ b/proto/wippersnapper/uart.proto
@@ -56,19 +56,6 @@ enum PacketFormat {
 }
 
 /**
-* DeviceType represents the type of device connected to the UART port.
-* This is used to determine the driver to use for the device.
-*/
-enum DeviceType {
-  DT_UNSPECIFIED    = 0; /** Unspecified device type. */
-  DT_GENERIC_INPUT  = 1; /** Use UART input. */
-  DT_GENERIC_OUTPUT = 2; /** Use the Generic UART output driver. */
-  DT_GPS            = 3; /** Use the GPS driver. */
-  DT_PM25AQI        = 4; /** Use the PM2.5 driver. */
-  DT_TM22XX         = 5; /** Use the TM22XX stepper driver. */
-}
-
-/**
 * GenericDeviceLineEnding represents the line ending used by the device.
 * This is used to determine how to parse the incoming data.
 */
@@ -141,9 +128,8 @@ message DeviceConfig {
 * Descriptor represents a message that uniquely identifies a UART device.
 */
 message Descriptor {
-  uint32 uart_nbr     = 1; /** The UART port number (eg: 0, 1, 2, etc.) that the device is attached to. */
-  DeviceType type     = 2; /** The category of device attached to the UART port, corresponds to its driver type. */
-  string id           = 3; /** The unique identifier string for the UART device. */
+  uint32 pin_scl = 1; /** The pin on which to receive on. */
+  uint32 pin_sda = 2; /** The pin on which to transmit with. */
 }
 
 /**
@@ -151,10 +137,11 @@ message Descriptor {
 * to configure a device on a UART port for communication.
 */
 message Add {
-  Descriptor   descriptor = 1; /** The descriptor of the device to add. */
-  SerialConfig cfg_serial = 2; /** The Serial configuration. */
-  DeviceConfig cfg_device = 3; /** The device-specific configuration. */
-  Write write             = 4; /** Optional initial write for a UART device, used during check-in. */
+  string name             = 1; /** The name of the device to add. */
+  Descriptor   descriptor = 2; /** The descriptor of the device to add. */
+  SerialConfig cfg_serial = 3; /** The Serial configuration. */
+  DeviceConfig cfg_device = 4; /** The device-specific configuration. */
+  Write write             = 5; /** Optional initial write for a UART device, used during check-in. */
 }
 
 /*


### PR DESCRIPTION
⚠️  **This is a breaking change for v2 api.** ⚠️ 

This pull request aligns the uart.proto `message`s by removing duplicated fields in `DeviceConfig`, `SerialConfig` to allow `Descriptor` being passed by an `Add` message (and all the messages).



Related: https://github.com/adafruit/Wippersnapper_Protobuf/pull/196