### PR TITLE
api-v2: use string pin names for i2c bus and uart rx/tx pins

### DIFF
--- a/proto/wippersnapper/docs/i2c.md
+++ b/proto/wippersnapper/docs/i2c.md
@@ -49,8 +49,8 @@ The v2 I2C API uses message envelopes for cleaner organization:
 
 All I2C operations use a `DeviceDescriptor` to identify devices:
 
-- **pin_scl** (`uint32`) - Pin number for the I2C SCL line
-- **pin_sda** (`uint32`) - Pin number for the I2C SDA line
+- **pin_scl** (`string`) - Pin name for the I2C SCL line, e.g. "D22", "SCL"
+- **pin_sda** (`string`) - Pin name for the I2C SDA line, e.g. "D21", "SDA"
 - **device_address** (`uint32`) - 7-bit I2C address
 - **mux_address** (`uint32`) - Optional I2C multiplexer address
 - **mux_channel** (`uint32`) - Optional I2C multiplexer channel
@@ -59,8 +59,8 @@ All I2C operations use a `DeviceDescriptor` to identify devices:
 
 The `Scan` message requests a bus scan:
 
-- **pin_scl** (`uint32`) - SCL pin number
-- **pin_sda** (`uint32`) - SDA pin number
+- **pin_scl** (`string`) - SCL pin name
+- **pin_sda** (`string`) - SDA pin name
 - **mux_address** (`uint32`) - Optional multiplexer address to scan through
 
 ## Sequence Diagrams

--- a/proto/wippersnapper/i2c.options
+++ b/proto/wippersnapper/i2c.options
@@ -1,4 +1,6 @@
 # i2c.options
+ws.i2c.AddressSpace.pin_scl max_size:32
+ws.i2c.AddressSpace.pin_sda max_size:32
 ws.i2c.Probed.results max_count:16
 ws.i2c.Add.name       max_size:16
 ws.i2c.Add.types      max_count:16

--- a/proto/wippersnapper/i2c.proto
+++ b/proto/wippersnapper/i2c.proto
@@ -33,8 +33,8 @@ message D2B {
  * - when describing an entire mux (all channels), leave mux_channel blank
  */
 message AddressSpace {
-  uint32 pin_scl        = 1; /** Pin name for the I2C SCL line **/
-  uint32 pin_sda        = 2; /** Pin name for the I2C SDA line **/
+  string pin_scl        = 1; /** Pin name for the I2C SCL line, e.g. "D22", "A4", "SCL" **/
+  string pin_sda        = 2; /** Pin name for the I2C SDA line, e.g. "D21", "A5", "SDA" **/
   uint32 mux_address    = 3; /** Optional - I2C multiplexer address. **/
   uint32 mux_channel    = 4; /** Optional - I2C multiplexer channel, or blank for "all channels" **/
 }

--- a/proto/wippersnapper/uart.options
+++ b/proto/wippersnapper/uart.options
@@ -1,5 +1,7 @@
 # uart.options
 ws.uart.Add.name                 max_size: 32
+ws.uart.Descriptor.pin_rx        max_size: 32
+ws.uart.Descriptor.pin_tx        max_size: 32
 ws.uart.GenericInputConfig.types max_count:15
 ws.uart.PM25AQIConfig.types      max_count:15
 ws.uart.Event.events             max_count:15

--- a/proto/wippersnapper/uart.proto
+++ b/proto/wippersnapper/uart.proto
@@ -126,8 +126,8 @@ message DeviceConfig {
 * Descriptor represents a message that uniquely identifies a UART device.
 */
 message Descriptor {
-  uint32 pin_rx = 1; /** The pin on which to receive on. */
-  uint32 pin_tx = 2; /** The pin on which to transmit with. */
+  string pin_rx = 1; /** Name of the pin on which to receive on, e.g. "D16", "RX". */
+  string pin_tx = 2; /** Name of the pin on which to transmit with, e.g. "D17", "TX". */
 }
 
 /**


### PR DESCRIPTION
## Summary

Converts the last remaining integer pin fields in the api-v2 protos to strings, so every pin reference across the API uses pin *names*:

- `ws.i2c.AddressSpace.pin_scl` / `pin_sda`: `uint32` → `string` (max_size 32)
- `ws.uart.Descriptor.pin_rx` / `pin_tx`: `uint32` → `string` (max_size 32)

## Why

- The CircuitPython/Blinka WipperSnapper firmware addresses pins by board name (`"SDA"`, `"SCL"`, etc.) for I2C bus scans and components — integer-only fields can't express those.
- IO expander pins use the `"EXP_0x48_0"` name format, which the rest of the API (digitalio/analogio `pin_name`) already supports via strings.
- Every other pin field in api-v2 (`pwm.pin`, `servo.servo_pin`, `ds18x20.onewire_pin`, `pixels.pin_data`, `spi`/`display` `pin_*`, `sleep.pin_name`, ...) is already a string like `"D5"`/`"A2"` — this makes i2c + uart consistent.

Docs in `docs/i2c.md` updated to match. `checkin.total_gpio_pins`/`total_analog_pins` are left as ints since they're counts of pins, not pin identifiers.

## Companion PR

Firmware-side changes (regenerated nanopb + pin-name resolution): adafruit/Adafruit_Wippersnapper_Arduino#943

🤖 Generated with [Claude Code](https://claude.com/claude-code)