### PR TITLE
display: carry all i8080 panel pins in the proto (wr/rd strobes + Add.pin_power)

### DIFF
--- a/proto/wippersnapper/display.options
+++ b/proto/wippersnapper/display.options
@@ -8,6 +8,7 @@ ws.display.DisplayProperties.status_bar         initializer:"true"
 ws.display.Add.driver                           max_size:32
 ws.display.Add.panel                            max_size:32
 ws.display.Add.name                             max_size:64
+ws.display.Add.pin_power                        max_size:6
 
 # Display-specific SPI pin constraints (shared SPI pins are in spi.options)
 ws.display.TftSpiDescriptor.pin_dc                  max_size:6
@@ -38,6 +39,8 @@ ws.display.I8080PinDescriptor.pin_d7                max_size:6
 ws.display.I8080PinDescriptor.pin_cs                max_size:6
 ws.display.I8080PinDescriptor.pin_dc                max_size:6
 ws.display.I8080PinDescriptor.pin_rst               max_size:6
+ws.display.I8080PinDescriptor.pin_wr                max_size:6
+ws.display.I8080PinDescriptor.pin_rd                max_size:6
 
 ws.display.DsiInterfaceDescriptor.pin_rst            max_size:6
 

--- a/proto/wippersnapper/display.options
+++ b/proto/wippersnapper/display.options
@@ -8,7 +8,6 @@ ws.display.DisplayProperties.status_bar         initializer:"true"
 ws.display.Add.driver                           max_size:32
 ws.display.Add.panel                            max_size:32
 ws.display.Add.name                             max_size:64
-ws.display.Add.pin_power                        max_size:6
 
 # Display-specific SPI pin constraints (shared SPI pins are in spi.options)
 ws.display.TftSpiDescriptor.pin_dc                  max_size:6
@@ -39,8 +38,8 @@ ws.display.I8080PinDescriptor.pin_d7                max_size:6
 ws.display.I8080PinDescriptor.pin_cs                max_size:6
 ws.display.I8080PinDescriptor.pin_dc                max_size:6
 ws.display.I8080PinDescriptor.pin_rst               max_size:6
-ws.display.I8080PinDescriptor.pin_wr                max_size:6
-ws.display.I8080PinDescriptor.pin_rd                max_size:6
+ws.display.I8080PinDescriptor.pin_write             max_size:6
+ws.display.I8080PinDescriptor.pin_read              max_size:6
 
 ws.display.DsiInterfaceDescriptor.pin_rst            max_size:6
 

--- a/proto/wippersnapper/display.proto
+++ b/proto/wippersnapper/display.proto
@@ -155,8 +155,8 @@ message I8080PinDescriptor {
   string pin_cs  = 9; /** Pin for chip select */
   string pin_dc  = 10; /** Pin for data/command */
   string pin_rst = 11; /** Pin for reset */
-  string pin_wr  = 12; /** Pin for the write strobe */
-  string pin_rd  = 13; /** Pin for the read strobe (empty if not wired/used) */
+  string pin_write = 12; /** Pin for the write strobe */
+  string pin_read  = 13; /** Pin for the read strobe (empty if not wired/used) */
 }
 
 /**
@@ -234,7 +234,9 @@ message Add {
   }
   Write write               = 10; /** Optional initial write for a display, used during check-in. */
   BacklightConfig backlight = 11; /** Optional backlight configuration (shared across display types). */
-  string pin_power          = 12; /** Optional panel power-enable pin, driven high before init (empty if none). */
+  ws.digitalio.Add power    = 12; /** Optional prerequisite digital output (e.g. a panel power-enable
+                                      rail on boards like the LilyGo T-Display-S3), configured before
+                                      display init. Supports is_inverted + an initial write. */
 }
 
 /**

--- a/proto/wippersnapper/display.proto
+++ b/proto/wippersnapper/display.proto
@@ -155,6 +155,8 @@ message I8080PinDescriptor {
   string pin_cs  = 9; /** Pin for chip select */
   string pin_dc  = 10; /** Pin for data/command */
   string pin_rst = 11; /** Pin for reset */
+  string pin_wr  = 12; /** Pin for the write strobe */
+  string pin_rd  = 13; /** Pin for the read strobe (empty if not wired/used) */
 }
 
 /**
@@ -232,6 +234,7 @@ message Add {
   }
   Write write               = 10; /** Optional initial write for a display, used during check-in. */
   BacklightConfig backlight = 11; /** Optional backlight configuration (shared across display types). */
+  string pin_power          = 12; /** Optional panel power-enable pin, driven high before init (empty if none). */
 }
 
 /**


### PR DESCRIPTION
Per review on adafruit/Adafruit_Wippersnapper_Arduino#936 (the LilyGo T-Display-S3 i8080 display support): every pin in a board's display magic config should come through the protobuf, with no board-hardcoded pins in the firmware.

- **`I8080PinDescriptor`** gains `pin_wr = 12` / `pin_rd = 13` — the 8080 bus strobes belong to the interface descriptor like every other bus pin (`rd` may be empty when not wired).
- **`Add`** gains an optional **`pin_power = 12`** — panel power-enable, driven high before init (e.g. the T-Display-S3 gates the panel rail on GPIO15).
- Backlight already rides `Add.backlight` (`BacklightConfig`, digitalio/pwm oneof) — unchanged.
- `display.options`: `max_size:6` for the three new pin strings.

With these, the LilyGo magic config (`d0–d7 / cs / dc / wr / rd / rst / backlight / powerOn`) maps 1:1 onto the proto. Firmware side (nanopb regen + driver wiring, removing the `I8080_*` board macros) is on adafruit/Adafruit_Wippersnapper_Arduino#936; verified end-to-end on real hardware via the HIL bench.

🤖 Generated with [Claude Code](https://claude.com/claude-code)