### PR TITLE
Add downstream protobuf asset sync CI (V2: Arduino migrate-api-v2, Python, protomq)

### DIFF
--- a/.github/workflows/sync-downstream.yml
+++ b/.github/workflows/sync-downstream.yml
@@ -6,15 +6,18 @@
 #
 #   master (V1 protos):
 #     - Adafruit_Wippersnapper_Arduino, base `main`          -> src/wippersnapper/
-#     - protomq, base `main`                                 -> protobufs-v1/ + protobufs/
+#     - protomq, base `main`                                 -> protobufs-v1/
 #   api-v2 (V2 protos):
 #     - Adafruit_Wippersnapper_Arduino, base `migrate-api-v2` -> src/protos/
 #     - Adafruit_Wippersnapper_Python,  base `main`           -> src/Adafruit_WipperSnapper_Python/*/pb2.py
-#     - protomq, base `main`                                  -> protobufs-v1/ + protobufs/
+#     - protomq, base `main`                                  -> protobufs-v1/
 #
-# protomq always regenerates BOTH bundles (it checks out this repo at master
-# and api-v2 and runs `npm run import-protos`), so only genuinely changed
-# assets show up in its PR diff.
+# protomq regenerates BOTH bundles via `npm run import-protos` (the script
+# requires a V2 source, and this validates both proto sets still compile),
+# but only protobufs-v1/ is committed. protobufs/ (V2) is intentionally
+# gitignored — V2 protos are supplied by a submodule / local import, keeping
+# import-protos + build-web and simultaneous V1+V2 testing working — so a
+# V2-only change produces no protomq PR.
 #
 # Each target gets a single rolling PR (branch `protobuf-sync/...`) that is
 # force-updated on subsequent runs until merged, like dependabot.
@@ -134,23 +137,27 @@ jobs:
           token: ${{ secrets.WS_SYNC_PAT }}
           path: target-repo
 
-      - name: Copy generated wrappers
+      - name: Check for proto modules missing from update_protobuf.py
         run: |
-          # Repo convention: <component>_pb2.py lives at
-          # src/Adafruit_WipperSnapper_Python/<component>/pb2.py, alongside
-          # hand-written code — so only pb2.py files are replaced, never
-          # whole directories. nanopb_pb2.py sits at the package root.
-          pkg=target-repo/src/Adafruit_WipperSnapper_Python
+          # The repo's update script copies only the modules in its hardcoded
+          # PROTOBUF_FILES list. Fail loudly when a new proto appears upstream
+          # so the list gets extended instead of the module being silently
+          # dropped. (Removed protos already fail inside the script itself.)
+          unmapped=""
           shopt -s nullglob
           for f in python_out/*_pb2.py; do
             name="$(basename "$f" _pb2.py)"
-            if [ "$name" = "nanopb" ]; then
-              cp "$f" "$pkg/nanopb_pb2.py"
-            else
-              mkdir -p "$pkg/$name"
-              cp "$f" "$pkg/$name/pb2.py"
-            fi
+            [ "$name" = "nanopb" ] && continue
+            grep -q "\"$name\"" target-repo/update_protobuf.py || unmapped="$unmapped $name"
           done
+          if [ -n "$unmapped" ]; then
+            echo "::error::New proto module(s) not in update_protobuf.py PROTOBUF_FILES:$unmapped"
+            exit 1
+          fi
+
+      - name: Update pb2 files via repo script
+        working-directory: target-repo
+        run: python3 update_protobuf.py "$GITHUB_WORKSPACE/python_out"
 
       - uses: peter-evans/create-pull-request@v7
         with:
@@ -162,14 +169,16 @@ jobs:
           commit-message: Update protobuf wrappers from Wippersnapper_Protobuf@${{ github.sha }}
           title: Update protobuf assets (${{ github.ref_name }})
           body: |
-            Auto-generated protobuf `pb2.py` update.
+            Auto-generated protobuf `pb2.py` update, applied with the repo's
+            own `update_protobuf.py`.
 
             Source: adafruit/Wippersnapper_Protobuf@${{ github.sha }} (branch `${{ github.ref_name }}`)
             Workflow: [`sync-downstream.yml`](https://github.com/adafruit/Wippersnapper_Protobuf/blob/${{ github.ref_name }}/.github/workflows/sync-downstream.yml)
 
-            Only `*/pb2.py` files are touched; hand-written module code is left
-            alone. If a proto was *removed* upstream its stale `pb2.py` must be
-            deleted manually.
+            Only the modules in `update_protobuf.py`'s PROTOBUF_FILES list are
+            touched; hand-written module code is left alone. The sync job fails
+            (no PR update) if upstream adds a proto missing from that list or
+            removes one the list still expects.
 
             This PR is force-updated on every merge to `${{ github.ref_name }}` until it is merged.
 
@@ -211,15 +220,6 @@ jobs:
           npm ci
           npm run import-protos
 
-      - name: Track V2 bundle
-        working-directory: protomq
-        # protobufs/* is gitignored but protobufs.js hard-imports
-        # protobufs/bundle.json, so a fresh clone can't run without a local
-        # import. Un-ignore it so the V2 assets ship in the repo like
-        # protobufs-v1/ already does. Drop this step (and the gitignore line
-        # stays) if protomq maintainers prefer dev-time imports for V2.
-        run: sed -i '\|^protobufs/\*$|d' .gitignore
-
       - uses: peter-evans/create-pull-request@v7
         with:
           token: ${{ secrets.WS_SYNC_PAT }}
@@ -227,17 +227,16 @@ jobs:
           branch: protobuf-sync/assets
           base: main
           delete-branch: true
-          commit-message: Update protobuf assets from Wippersnapper_Protobuf@${{ github.sha }}
-          title: Update protobuf assets (V1 + V2)
+          commit-message: Update V1 protobuf assets from Wippersnapper_Protobuf@${{ github.sha }}
+          title: Update V1 protobuf assets
           body: |
-            Auto-generated proto/bundle update via `npm run import-protos`,
-            sourced from adafruit/Wippersnapper_Protobuf `master` (V1) and
-            `api-v2` (V2). Triggered by a merge to `${{ github.ref_name }}`
+            Auto-generated `protobufs-v1/` update via `npm run import-protos`,
+            sourced from adafruit/Wippersnapper_Protobuf `master`. Triggered by
+            a merge to `${{ github.ref_name }}`
             (adafruit/Wippersnapper_Protobuf@${{ github.sha }}).
 
-            Note: this also removes the `protobufs/*` gitignore entry so the
-            generated V2 bundle is committed — `protobufs.js` imports
-            `protobufs/bundle.json` at startup, which previously required a
-            local `npm run import-protos` on every fresh clone.
+            The V2 bundle was regenerated in the same run (validating the
+            `api-v2` protos still compile) but is not committed — `protobufs/`
+            is intentionally gitignored and sourced separately.
 
             This PR is force-updated on every upstream merge until it is merged.

--- a/.github/workflows/sync-downstream.yml
+++ b/.github/workflows/sync-downstream.yml
@@ -1,0 +1,243 @@
+# Dependabot-style sync of generated protobuf assets to downstream repos.
+#
+# Runs when a PR is merged (push) to `master` or `api-v2`. This file must exist
+# on BOTH branches with identical content — GitHub runs the copy that lives on
+# the branch that was pushed. Routing:
+#
+#   master (V1 protos):
+#     - Adafruit_Wippersnapper_Arduino, base `main`          -> src/wippersnapper/
+#     - protomq, base `main`                                 -> protobufs-v1/ + protobufs/
+#   api-v2 (V2 protos):
+#     - Adafruit_Wippersnapper_Arduino, base `migrate-api-v2` -> src/protos/
+#     - Adafruit_Wippersnapper_Python,  base `main`           -> src/Adafruit_WipperSnapper_Python/*/pb2.py
+#     - protomq, base `main`                                  -> protobufs-v1/ + protobufs/
+#
+# protomq always regenerates BOTH bundles (it checks out this repo at master
+# and api-v2 and runs `npm run import-protos`), so only genuinely changed
+# assets show up in its PR diff.
+#
+# Each target gets a single rolling PR (branch `protobuf-sync/...`) that is
+# force-updated on subsequent runs until merged, like dependabot.
+#
+# Required secret: WS_SYNC_PAT — a PAT with contents:write and
+# pull-requests:write on Adafruit_Wippersnapper_Arduino,
+# Adafruit_Wippersnapper_Python (private) and protomq.
+name: Sync Downstream Assets
+
+on:
+  push:
+    branches: [master, api-v2]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  actions: read # download-artifact within the run
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - name: Tool Dependencies
+        uses: jdx/mise-action@v2
+
+      - name: Lib Dependencies
+        run: pip install protobuf 'setuptools==75.3.4'
+
+      - name: Build Arduino
+        run: bin/build-arduino
+
+      - name: Build Python
+        run: bin/build-python
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: sync-arduino-wrapper
+          path: ./arduino_out
+          if-no-files-found: error
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: sync-python-wrapper
+          path: ./python_out
+          if-no-files-found: error
+
+  sync-arduino:
+    needs: build
+    runs-on: ubuntu-latest
+    concurrency:
+      group: protobuf-sync-arduino-${{ github.ref_name }}
+    env:
+      SOURCE_BRANCH: ${{ github.ref_name }}
+      TARGET_BRANCH: ${{ github.ref_name == 'api-v2' && 'migrate-api-v2' || 'main' }}
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: sync-arduino-wrapper
+          path: arduino_out
+
+      - uses: actions/checkout@v4
+        with:
+          repository: adafruit/Adafruit_Wippersnapper_Arduino
+          ref: ${{ env.TARGET_BRANCH }}
+          token: ${{ secrets.WS_SYNC_PAT }}
+          path: target-repo
+
+      - name: Copy generated wrappers
+        run: |
+          if [ "$SOURCE_BRANCH" = "api-v2" ]; then
+            # V2: flat *.pb.c/h files into src/protos/
+            rsync -a --delete \
+              --include='*.pb.c' --include='*.pb.h' --exclude='*' \
+              arduino_out/ target-repo/src/protos/
+          else
+            # V1: nested wippersnapper/<component>/v1/ tree into src/wippersnapper/
+            rsync -a --delete arduino_out/wippersnapper/ target-repo/src/wippersnapper/
+          fi
+
+      - uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ secrets.WS_SYNC_PAT }}
+          path: target-repo
+          branch: protobuf-sync/${{ github.ref_name }}
+          base: ${{ env.TARGET_BRANCH }}
+          delete-branch: true
+          commit-message: Update protobuf wrappers from Wippersnapper_Protobuf@${{ github.sha }}
+          title: Update protobuf assets (${{ github.ref_name }})
+          body: |
+            Auto-generated nanopb wrapper update.
+
+            Source: adafruit/Wippersnapper_Protobuf@${{ github.sha }} (branch `${{ github.ref_name }}`)
+            Workflow: [`sync-downstream.yml`](https://github.com/adafruit/Wippersnapper_Protobuf/blob/${{ github.ref_name }}/.github/workflows/sync-downstream.yml)
+
+            This PR is force-updated on every merge to `${{ github.ref_name }}` until it is merged.
+
+  sync-python:
+    needs: build
+    if: github.ref_name == 'api-v2'
+    runs-on: ubuntu-latest
+    concurrency:
+      group: protobuf-sync-python
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: sync-python-wrapper
+          path: python_out
+
+      - uses: actions/checkout@v4
+        with:
+          repository: adafruit/Adafruit_Wippersnapper_Python
+          ref: main
+          token: ${{ secrets.WS_SYNC_PAT }}
+          path: target-repo
+
+      - name: Copy generated wrappers
+        run: |
+          # Repo convention: <component>_pb2.py lives at
+          # src/Adafruit_WipperSnapper_Python/<component>/pb2.py, alongside
+          # hand-written code — so only pb2.py files are replaced, never
+          # whole directories. nanopb_pb2.py sits at the package root.
+          pkg=target-repo/src/Adafruit_WipperSnapper_Python
+          shopt -s nullglob
+          for f in python_out/*_pb2.py; do
+            name="$(basename "$f" _pb2.py)"
+            if [ "$name" = "nanopb" ]; then
+              cp "$f" "$pkg/nanopb_pb2.py"
+            else
+              mkdir -p "$pkg/$name"
+              cp "$f" "$pkg/$name/pb2.py"
+            fi
+          done
+
+      - uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ secrets.WS_SYNC_PAT }}
+          path: target-repo
+          branch: protobuf-sync/${{ github.ref_name }}
+          base: main
+          delete-branch: true
+          commit-message: Update protobuf wrappers from Wippersnapper_Protobuf@${{ github.sha }}
+          title: Update protobuf assets (${{ github.ref_name }})
+          body: |
+            Auto-generated protobuf `pb2.py` update.
+
+            Source: adafruit/Wippersnapper_Protobuf@${{ github.sha }} (branch `${{ github.ref_name }}`)
+            Workflow: [`sync-downstream.yml`](https://github.com/adafruit/Wippersnapper_Protobuf/blob/${{ github.ref_name }}/.github/workflows/sync-downstream.yml)
+
+            Only `*/pb2.py` files are touched; hand-written module code is left
+            alone. If a proto was *removed* upstream its stale `pb2.py` must be
+            deleted manually.
+
+            This PR is force-updated on every merge to `${{ github.ref_name }}` until it is merged.
+
+  sync-protomq:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: protobuf-sync-protomq
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          repository: adafruit/protomq
+          ref: main
+          token: ${{ secrets.WS_SYNC_PAT }}
+          path: protomq
+
+      - uses: actions/checkout@v4
+        with:
+          ref: api-v2
+          path: proto-v2
+
+      - uses: actions/checkout@v4
+        with:
+          ref: master
+          path: proto-v1
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Import protos
+        working-directory: protomq
+        run: |
+          cat > .env.json <<EOF
+          {
+            "protobufSource": "${{ github.workspace }}/proto-v2/proto",
+            "protobufSourceV1": "${{ github.workspace }}/proto-v1/proto"
+          }
+          EOF
+          npm ci
+          npm run import-protos
+
+      - name: Track V2 bundle
+        working-directory: protomq
+        # protobufs/* is gitignored but protobufs.js hard-imports
+        # protobufs/bundle.json, so a fresh clone can't run without a local
+        # import. Un-ignore it so the V2 assets ship in the repo like
+        # protobufs-v1/ already does. Drop this step (and the gitignore line
+        # stays) if protomq maintainers prefer dev-time imports for V2.
+        run: sed -i '\|^protobufs/\*$|d' .gitignore
+
+      - uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ secrets.WS_SYNC_PAT }}
+          path: protomq
+          branch: protobuf-sync/assets
+          base: main
+          delete-branch: true
+          commit-message: Update protobuf assets from Wippersnapper_Protobuf@${{ github.sha }}
+          title: Update protobuf assets (V1 + V2)
+          body: |
+            Auto-generated proto/bundle update via `npm run import-protos`,
+            sourced from adafruit/Wippersnapper_Protobuf `master` (V1) and
+            `api-v2` (V2). Triggered by a merge to `${{ github.ref_name }}`
+            (adafruit/Wippersnapper_Protobuf@${{ github.sha }}).
+
+            Note: this also removes the `protobufs/*` gitignore entry so the
+            generated V2 bundle is committed — `protobufs.js` imports
+            `protobufs/bundle.json` at startup, which previously required a
+            local `npm run import-protos` on every fresh clone.
+
+            This PR is force-updated on every upstream merge until it is merged.


### PR DESCRIPTION
Companion to #210 — adds the identical `sync-downstream.yml` to `api-v2` (push-triggered workflows run from the copy on the pushed branch, so it must exist on both branches).

On merge to `api-v2` this opens/updates rolling PRs against:
- `Adafruit_Wippersnapper_Arduino` → `migrate-api-v2` (flat `src/protos/*.pb.{c,h}`)
- `Adafruit_Wippersnapper_Python` → `main` (applied with the repo's own `update_protobuf.py`; fails loudly on modules missing from its list)
- `protomq` → `main` (`protobufs-v1/` only, when V1 output changed; the V2 bundle is regenerated as a compile check but stays gitignored by design)

See #210 for full details and the required `WS_SYNC_PAT` secret setup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)