### PR TITLE
feat(telemetry): identify metrics by Type enum instead of string name

### DIFF
--- a/proto/wippersnapper/telemetry.options
+++ b/proto/wippersnapper/telemetry.options
@@ -1,5 +1,2 @@
 # telemetry.options
 # Nanopb configuration for telemetry.proto
-#
-# The telemetry metric is identified by the ws.telemetry.Type enum, which
-# encodes to a fixed-width varint, so no max_size overrides are required.

--- a/proto/wippersnapper/telemetry.options
+++ b/proto/wippersnapper/telemetry.options
@@ -1,5 +1,5 @@
 # telemetry.options
 # Nanopb configuration for telemetry.proto
-ws.telemetry.Add.name           max_size:24
-ws.telemetry.Event.name         max_size:24
-ws.telemetry.Remove.name        max_size:24
+#
+# The telemetry metric is identified by the ws.telemetry.Type enum, which
+# encodes to a fixed-width varint, so no max_size overrides are required.

--- a/proto/wippersnapper/telemetry.options
+++ b/proto/wippersnapper/telemetry.options
@@ -1,2 +1,4 @@
 # telemetry.options
 # Nanopb configuration for telemetry.proto
+
+ws.telemetry.Add.report_once         initializer:"false"

--- a/proto/wippersnapper/telemetry.proto
+++ b/proto/wippersnapper/telemetry.proto
@@ -5,6 +5,18 @@ package ws.telemetry;
 import "sensor.proto";
 
 /**
+ * Type enumerates the telemetry metrics a device can report.
+ * Each value identifies a distinct telemetry component. The broker fills the
+ * value and the device maps it directly to a reader, so no string name lookup
+ * or name->kind resolution is required on the device.
+ */
+enum Type {
+  TM_UNSPECIFIED = 0; /** Unspecified telemetry metric, error. */
+  TM_RSSI        = 1; /** Wi-Fi signal strength, in dBm (ws.sensor.Event.float_value, T_RAW). */
+  TM_BOOT_REASON = 2; /** Reset / boot reason string (ws.sensor.Event.bytes_value, T_BYTES). */
+}
+
+/**
  * BrokerToDevice message envelope.
  * Used to add or remove a telemetry component on the device.
  */
@@ -27,24 +39,24 @@ message D2B {
 
 /**
  * Add instructs a device to create a telemetry component and start reporting it.
- * Each telemetry metric (e.g. "rssi", "free_heap", "boot_count") is its own component instance.
+ * Each telemetry metric (e.g. TM_RSSI, TM_BOOT_REASON) is its own component instance.
  */
 message Add {
-  string name   = 1; /** Unique name identifying this telemetry component (e.g. "rssi", "free_heap"). */
-  float  period = 2; /** Reporting interval, in seconds. Use 0 to only report at startup. */
+  Type  type   = 1; /** Which telemetry metric to create and report. */
+  float period = 2; /** Reporting interval, in seconds. Use 0 to only report at startup. */
 }
 
 /**
  * Remove instructs a device to stop reporting and destroy a telemetry component.
  */
 message Remove {
-  string name = 1; /** Name of the telemetry component to remove. */
+  Type type = 1; /** Which telemetry metric to remove. */
 }
 
 /**
  * Event carries a periodic or triggered reading from a telemetry component.
  */
 message Event {
-  string          name  = 1; /** Name of the telemetry component. */
+  Type            type  = 1; /** Which telemetry metric this reading is for. */
   ws.sensor.Event value = 2; /** The metric's value (float_value, bool_value, bytes_value, etc.). */
 }

--- a/proto/wippersnapper/telemetry.proto
+++ b/proto/wippersnapper/telemetry.proto
@@ -47,9 +47,9 @@ message D2B {
  * Each telemetry metric (e.g. TM_RSSI, TM_BOOT_REASON) is its own component instance.
  */
 message Add {
-  Type type       = 1; /** Which telemetry metric to create and report. */
-  float period    = 2; /** Reporting interval, in seconds. Use 0 to only report at startup. */
-  bool reportOnce = 3; /** If true, the device will only report this metric once, at startup. */
+  Type type        = 1; /** Which telemetry metric to create and report. */
+  float period     = 2; /** Reporting interval, in seconds. Use 0 to only report at startup. */
+  bool report_once = 3; /** If true, the device will only report this metric once, at startup. */
 }
 
 /**

--- a/proto/wippersnapper/telemetry.proto
+++ b/proto/wippersnapper/telemetry.proto
@@ -12,7 +12,6 @@ enum Type {
 
   // Boot / reset / report_once metrics (1-9).
   TM_BOOT_REASON = 1; /** Reset / boot reason string (ws.sensor.Event.bytes_value, T_BYTES). */
-  TM_BOOT_COUNT  = 2; /** Number of boots since first power-on (ws.sensor.Event.float_value, T_RAW). */
 
   // Net / Radio / regular reporting metrics (10-19).
   TM_RSSI    = 10; /** Wi-Fi signal strength, in dBm (ws.sensor.Event.float_value, T_RAW). */

--- a/proto/wippersnapper/telemetry.proto
+++ b/proto/wippersnapper/telemetry.proto
@@ -10,15 +10,16 @@ import "sensor.proto";
 enum Type {
   TM_UNSPECIFIED = 0; /** Unspecified telemetry metric, error. */
 
-  // Boot / reset metrics (1-9).
+  // Boot / reset / report_once metrics (1-9).
   TM_BOOT_REASON = 1; /** Reset / boot reason string (ws.sensor.Event.bytes_value, T_BYTES). */
   TM_BOOT_COUNT  = 2; /** Number of boots since first power-on (ws.sensor.Event.float_value, T_RAW). */
 
-  // Connectivity / latency metrics (10-19).
+  // Net / Radio / regular reporting metrics (10-19).
   TM_RSSI    = 10; /** Wi-Fi signal strength, in dBm (ws.sensor.Event.float_value, T_RAW). */
   TM_LATENCY = 11; /** Broker round-trip latency, in ms (ws.sensor.Event.float_value, T_RAW). */
 
-  // Next metric category (memory / resource, etc.) begins at 20.
+  // Custom frequency reporting (memory / resource, etc.) begins at 20.
+  // e.g. send free mem after display graphics loaded
 }
 
 /**

--- a/proto/wippersnapper/telemetry.proto
+++ b/proto/wippersnapper/telemetry.proto
@@ -47,8 +47,9 @@ message D2B {
  * Each telemetry metric (e.g. TM_RSSI, TM_BOOT_REASON) is its own component instance.
  */
 message Add {
-  Type  type   = 1; /** Which telemetry metric to create and report. */
-  float period = 2; /** Reporting interval, in seconds. Use 0 to only report at startup. */
+  Type type       = 1; /** Which telemetry metric to create and report. */
+  float period    = 2; /** Reporting interval, in seconds. Use 0 to only report at startup. */
+  bool reportOnce = 3; /** If true, the device will only report this metric once, at startup. */
 }
 
 /**

--- a/proto/wippersnapper/telemetry.proto
+++ b/proto/wippersnapper/telemetry.proto
@@ -6,9 +6,6 @@ import "sensor.proto";
 
 /**
  * Type enumerates the telemetry metrics a device can report.
- * Each value identifies a distinct telemetry component. The broker fills the
- * value and the device maps it directly to a reader, so no string name lookup
- * or name->kind resolution is required on the device.
  */
 enum Type {
   TM_UNSPECIFIED = 0; /** Unspecified telemetry metric, error. */
@@ -18,8 +15,8 @@ enum Type {
   TM_BOOT_COUNT  = 2; /** Number of boots since first power-on (ws.sensor.Event.float_value, T_RAW). */
 
   // Connectivity / latency metrics (10-19).
-  TM_RSSI        = 10; /** Wi-Fi signal strength, in dBm (ws.sensor.Event.float_value, T_RAW). */
-  TM_LATENCY_MS  = 11; /** Broker round-trip latency, in ms; e.g. Python SBC hosts (ws.sensor.Event.float_value, T_RAW). */
+  TM_RSSI    = 10; /** Wi-Fi signal strength, in dBm (ws.sensor.Event.float_value, T_RAW). */
+  TM_LATENCY = 11; /** Broker round-trip latency, in ms (ws.sensor.Event.float_value, T_RAW). */
 
   // Next metric category (memory / resource, etc.) begins at 20.
 }

--- a/proto/wippersnapper/telemetry.proto
+++ b/proto/wippersnapper/telemetry.proto
@@ -12,8 +12,16 @@ import "sensor.proto";
  */
 enum Type {
   TM_UNSPECIFIED = 0; /** Unspecified telemetry metric, error. */
-  TM_RSSI        = 1; /** Wi-Fi signal strength, in dBm (ws.sensor.Event.float_value, T_RAW). */
-  TM_BOOT_REASON = 2; /** Reset / boot reason string (ws.sensor.Event.bytes_value, T_BYTES). */
+
+  // Boot / reset metrics (1-9).
+  TM_BOOT_REASON = 1; /** Reset / boot reason string (ws.sensor.Event.bytes_value, T_BYTES). */
+  TM_BOOT_COUNT  = 2; /** Number of boots since first power-on (ws.sensor.Event.float_value, T_RAW). */
+
+  // Connectivity / latency metrics (10-19).
+  TM_RSSI        = 10; /** Wi-Fi signal strength, in dBm (ws.sensor.Event.float_value, T_RAW). */
+  TM_LATENCY_MS  = 11; /** Broker round-trip latency, in ms; e.g. Python SBC hosts (ws.sensor.Event.float_value, T_RAW). */
+
+  // Next metric category (memory / resource, etc.) begins at 20.
 }
 
 /**


### PR DESCRIPTION
## Summary

Replaces the free-form `string name` field on `ws.telemetry.Add` / `Remove` / `Event` with a new `ws.telemetry.Type` **enum**, so a telemetry metric is defined by the component library and filled by the broker rather than matched by string on the device.

Addresses review feedback on [Adafruit_Wippersnapper_Arduino#946](https://github.com/adafruit/Adafruit_Wippersnapper_Arduino/pull/946):

> Wouldn't this be best as an enum within `telemetry.proto` so it can be defined by the component, filled by the broker, and require no resolution or extra struct in the hardware?

## Change

`Add.name`, `Remove.name`, and `Event.name` (all `string`, field 1) become `Type type` (field 1). The enum is **spaced into numeric bands by category** so each group can grow without renumbering:

```proto
enum Type {
  TM_UNSPECIFIED = 0;

  // Boot / reset metrics (1-9).
  TM_BOOT_REASON = 1;   // bytes_value / T_BYTES
  TM_BOOT_COUNT  = 2;   // float_value / T_RAW

  // Connectivity / latency metrics (10-19).
  TM_RSSI        = 10;  // float_value / T_RAW
  TM_LATENCY_MS  = 11;  // float_value / T_RAW  (broker round-trip, e.g. Python SBC hosts)

  // Next metric category (memory / resource, etc.) begins at 20.
}
```

`Add.period` / `Event.value` are unchanged. `telemetry.options` drops its `max_size:24` lines — the enum is a fixed varint, so the name string fields (and their nanopb string handling) are gone.

## Why

- **No device-side resolution.** The firmware currently stores a per-instance name and resolves `"rssi"` / `"boot_reason"` → an internal `TelemetryKind`. With the enum on the wire, the broker's value maps straight to a reader — no name string, no `TelemetryKind` struct.
- **Cheaper on the wire and in nanopb.** Fixed varint instead of a length-delimited string with a `max_size` cap.
- **Standardized naming.** Uses `Type` (matching `ws.sensor.Type`, `ws.pixels.Type`) per the same review thread's request to rename `Kind` → `Type`.
- **Room to grow.** Banded numbering keeps related metrics together; new members extend the enum (e.g. a future memory/resource block at 20+).

## New metrics in this PR

Beyond the two already implemented in firmware (`TM_RSSI`, `TM_BOOT_REASON`), two reserved values are added to the contract:

- **`TM_BOOT_COUNT`** — boots since first power-on. Needs persistent storage (NVS/flash/RTC) to implement on-device; reserved wire value for now.
- **`TM_LATENCY_MS`** — broker round-trip latency; primarily aimed at Python / Linux SBC hosts. Not measured by the Arduino firmware today; reserved wire value for now.

## Notes

- Generated wrappers (arduino/js/python/docs) are produced by CI from these `.proto` / `.options` sources — no generated code is committed here. Verified nanopb generation locally: the `Type` enum (with the value gaps) and the scalar `type` fields on Add/Remove/Event generate cleanly; `_MAX` resolves to `TM_LATENCY_MS`.
- **Wire-breaking** vs. the just-merged string form, but telemetry is new on `api-v2` and unreleased, so no deployed devices are affected.

## Follow-up

Firmware PR #946 will be updated to consume the enum (drop the name→kind resolution, key Add/Remove/Event on `type`) once this lands and the wrappers regenerate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)